### PR TITLE
Build fix for FreeBSD.

### DIFF
--- a/rshim_pcie_lf.c
+++ b/rshim_pcie_lf.c
@@ -11,6 +11,8 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 
+#include <netinet/in.h>
+
 #include <pthread.h>
 
 #include "rshim.h"


### PR DESCRIPTION
Include definitions for ntohl() and htonl().

Signed-off-by: Hans Petter Selasky <hps@selasky.org>