### PR TITLE
This commit simplify the command line for the '-d' option. When

### DIFF
--- a/man/bfrshim.1
+++ b/man/bfrshim.1
@@ -69,10 +69,13 @@ cat /dev/rshim0/misc
 .in
 .SH OPTIONS
 -b, --backend
-    Specify the backend to attach, which can be one of usb, pcie or pcie_lf
+    Specify the backend to attach, which can be one of usb, pcie or pcie_lf.
+    If not specified, the driver will scan all rshim backends unless the '-d'
+    option is given with a device name specified.
 
 -d, --device
-    Specify the device name to attach with the format below
+    Specify the device name to attach with the format below. The backend driver
+    can be deduced from the device name, thus the '-b' option is not needed.
 
     PCIe backend:
         pcie-<bus>:<device>.<function>. Example: pcie-04:00.2

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -3328,6 +3328,14 @@ static void rshim_main(int argc, char *argv[])
 
   /* Scan rshim backends. */
   rc = 0;
+  if (!rshim_backend_name && rshim_device_filter) {
+    if (!strncmp(rshim_device_filter, "usb", 3))
+      rshim_backend_name = "usb";
+    else if (!strncmp(rshim_device_filter, "pcie", 4))
+      rshim_backend_name = "pcie";
+    else if (!strncmp(rshim_device_filter, "pcie_lf", 7))
+      rshim_backend_name = "pcie_lf";
+  }
   if (!rshim_backend_name) {
     rshim_pcie_init();
     rshim_usb_init(epoll_fd);


### PR DESCRIPTION
the '-d' option is provided with a device name, the backend type
can be deduced from it thus no need for the '-b' option.

Signed-off-by: Liming Sun <lsun@mellanox.com>