### PR TITLE
Enable pcie device during probing

### DIFF
--- a/src/rshim.h
+++ b/src/rshim.h
@@ -471,6 +471,7 @@ static inline void rshim_usb_poll(void)
 #ifdef HAVE_RSHIM_PCIE
 int rshim_pcie_init(void);
 int rshim_pcie_lf_init(void);
+void rshim_pcie_enable(void *dev);
 #else
 static inline int rshim_pcie_init(void)
 {

--- a/src/rshim_pcie_lf.c
+++ b/src/rshim_pcie_lf.c
@@ -575,10 +575,9 @@ int rshim_pcie_lf_init(void)
          dev->device_id != BLUEFIELD2_DEVICE_ID))
       continue;
 
+    rshim_pcie_enable(dev);
     rshim_pcie_probe(dev);
   }
-
-  //pci_cleanup(pci);
 
   return 0;
 }


### PR DESCRIPTION
This commit enables the rshim PF device before trying to bind it.
It's needed on some platforms that the device is not enabled by
default somehow.

Signed-off-by: Liming Sun <lsun@mellanox.com>