### PR TITLE
Add domain id to the DEV_NAME in the misc file

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -267,7 +267,7 @@ static ssize_t rshim_read_default(rshim_backend_t *bd, int devtype,
   if (bd->is_boot_open)
     return 0;
 
-  while (total < count && !bd->drop_mode) {
+  while (total < count) {
     if (avail == 0) {
       rc = bd->read_rshim(bd, RSHIM_CHANNEL, RSH_TM_TILE_TO_HOST_STS, &reg);
       if (rc < 0)
@@ -405,9 +405,6 @@ static ssize_t rshim_write_default(rshim_backend_t *bd, int devtype,
                                    const char *buf, size_t count)
 {
   int rc;
-
-  if (bd->drop_mode)
-    return count;
 
   switch (devtype) {
   case RSH_DEV_TYPE_TMFIFO:
@@ -1008,7 +1005,7 @@ static void rshim_fifo_input(rshim_backend_t *bd)
   uint8_t rx_avail = 0;
   int rc;
 
-  if (bd->drop_mode || bd->is_boot_open)
+  if (bd->is_boot_open)
     return;
 
 again:
@@ -1561,7 +1558,7 @@ static void rshim_work_handler(rshim_backend_t *bd)
     }
   }
 
-  if (bd->is_boot_open || bd->drop_mode) {
+  if (bd->is_boot_open) {
     pthread_mutex_unlock(&bd->mutex);
     return;
   }

--- a/src/rshim_pcie.c
+++ b/src/rshim_pcie.c
@@ -255,6 +255,10 @@ rshim_pcie_read(rshim_backend_t *bd, int chan, int addr, uint64_t *result)
 
   if (!bd->has_rshim)
     return -ENODEV;
+  if (bd->drop_mode) {
+    *result = 0;
+    return 0;
+  }
 
   dev->write_count = 0;
 
@@ -276,6 +280,8 @@ rshim_pcie_write(rshim_backend_t *bd, int chan, int addr, uint64_t value)
 
   if (!bd->has_rshim)
     return -ENODEV;
+  if (bd->drop_mode)
+    return 0;
 
   /*
    * We cannot stream large numbers of PCIe writes to the RShim's BAR.
@@ -318,8 +324,8 @@ static int rshim_pcie_probe(struct pci_dev *pci_dev)
 #endif
   int ret = 0;
 
-  snprintf(dev_name, sizeof(dev_name) - 1, "pcie-%02x:%02x.%x",
-           pci_dev->bus, pci_dev->dev, pci_dev->func);
+  snprintf(dev_name, sizeof(dev_name) - 1, "pcie-%04x:%02x:%02x.%x",
+           pci_dev->domain, pci_dev->bus, pci_dev->dev, pci_dev->func);
 
   if (!rshim_allow_device(dev_name))
     return -EACCES;

--- a/src/rshim_pcie_lf.c
+++ b/src/rshim_pcie_lf.c
@@ -482,8 +482,8 @@ static int rshim_pcie_probe(struct pci_dev *pci_dev)
   rshim_pcie_lf_t *dev;
   int ret;
 
-  snprintf(dev_name, sizeof(dev_name) - 1, "pcie-lf-%02x:%02x.%d",
-           pci_dev->bus, pci_dev->dev, pci_dev->func);
+  snprintf(dev_name, sizeof(dev_name) - 1, "pcie-lf-%04x:%02x:%02x.%d",
+           pci_dev->domain, pci_dev->bus, pci_dev->dev, pci_dev->func);
 
   if (!rshim_allow_device(dev_name))
     return -EACCES;


### PR DESCRIPTION
This commit adds domain id to the DEV_NAME in the misc file. It
also has some reliable changes to the drop_mode setting which
could be used during fw reset.

Signed-off-by: Liming Sun <lsun@mellanox.com>