### PR TITLE
Enhance rshim_pcie_enable function

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Copyright (C) 2019 Mellanox Technologies. All Rights Reserved.
 #
 
-AC_INIT([rshim], [2.0.4])
+AC_INIT([rshim], [2.0.5])
 AC_CONFIG_AUX_DIR(config)
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AC_LANG(C)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+rshim (2.0.5-1) UNRELEASED; urgency=low
+
+  * Improve response time to ctrl+c for boot stream
+  * Fix a rpmbuild issue when make_build is not defined
+  * Add DROP_MODE configuration in misc file
+  * Avoid reading the fifo if still booting
+  * Fix configure issue for FreeBSD 12.1-RELEASE
+  * Add domain id to the DEV_NAME in the misc file
+  * Fix the debian copyright format
+  * Enhance rshim_pcie_enable function
+
+ -- Liming Sun <lsun@mellanox.com>  Tue, 16 Jun 2020 13:58:10 -0400
+
 rshim (2.0.4-1) UNRELEASED; urgency=low
 
   * Update .spec file according to review comments

--- a/src/rshim.h
+++ b/src/rshim.h
@@ -375,6 +375,9 @@ struct rshim_backend {
   /* API to write 8 bytes to RShim. */
   int (*write_rshim)(rshim_backend_t *bd, int chan, int addr,
                      uint64_t value);
+
+  /* API to enable the device. */
+  int (*enable_device)(rshim_backend_t *bd, bool enable);
 };
 
 /* Global variables. */
@@ -486,7 +489,7 @@ static inline void rshim_usb_poll(void)
 #ifdef HAVE_RSHIM_PCIE
 int rshim_pcie_init(void);
 int rshim_pcie_lf_init(void);
-int rshim_pcie_enable(void *dev);
+int rshim_pcie_enable(void *dev, bool enable);
 #else
 static inline int rshim_pcie_init(void)
 {

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -811,6 +811,10 @@ static int rshim_fuse_misc_write(struct cuse_dev *cdev, int fflags,
     bd->drop_mode = !!value;
     if (bd->drop_mode)
       bd->drop_pkt = 1;
+    if (bd->enable_device) {
+      if (bd->enable_device(bd, true))
+        bd->drop_mode = 1;
+    }
   } else if (strcmp(key, "BOOT_MODE") == 0) {
     if (sscanf(p, "%x", &value) != 1)
       goto invalid;


### PR DESCRIPTION
This commit enhances rshim_pcie_enable in several ways.
- Add backend API enable_device for it. So other code could call
  it when needed;
- Call the enable_device API when backend is recovered from
  DROP_MODE.
- Check whether pcie is already being used bu another driver during
  the probe.

Signed-off-by: Liming Sun <lsun@mellanox.com>