### PR TITLE
Add configuration file support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,8 @@
 AUTOMAKE_OPTIONS = foreign
 SUBDIRS = src man
 dist_doc_DATA = README.md
+confdir = $(sysconfdir)
+dist_conf_DATA = etc/rshim.conf
 
 AM_DISTCHECK_CONFIGURE_FLAGS = \
   --with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+rshim (2.0.5-2) UNRELEASED; urgency=low
+
+  * Add configuration file support
+  * misc: Display device version / revision ID
+  * Add service file for FreeBSD
+
+ -- Liming Sun <lsun@mellanox.com>  Fri, 24 Jul 2020 08:06:20 -0400
+
 rshim (2.0.5-1) UNRELEASED; urgency=low
 
   * Improve response time to ctrl+c for boot stream

--- a/etc/rshim.conf
+++ b/etc/rshim.conf
@@ -1,0 +1,18 @@
+#
+# This is the rshim driver configuration file.
+#
+
+#
+# Static mapping of rshim name and device.
+# Uncomment the 'rshim<N>' line to configure the mapping.
+#
+# rshim-name  device-name
+#rshim0       usb-2-1.7
+#rshim1       pcie-0000:04:00.2
+
+#
+# Ignored rshim devices.
+# Uncomment the 'none' line to configure the ignored devices.
+#
+#none         usb-1-1.4
+#none         pcie-lf-0000:84:00.0

--- a/man/rshim.8
+++ b/man/rshim.8
@@ -112,3 +112,20 @@ Log messages will be printed to standard output when running in foreground, or i
 .in +4n
 Display version
 .in
+.SH CONFIGURATION FILE
+Rshim configuration file (/etc/rshim.conf) can be used to specify the static mapping between rshim devices and rshim names. It can also be used to ignore some rshim devices.
+
+Example:
+.in +4n
+# Map usb-2-1.7 to rshim0
+.br
+rshim0       usb-2-1.7
+
+# Map pcie-0000:04:00.2 to rshim1
+.br
+rshim1       pcie-0000:04:00.2
+
+# Ignore usb-1-1.4
+.br
+none         usb-1-1.4
+.in

--- a/rhel/rshim.spec.in
+++ b/rhel/rshim.spec.in
@@ -4,7 +4,7 @@
 
 Name: rshim
 Version: @VERSION@
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: User-space driver for Mellanox BlueField SoC
 
 License: GPLv2
@@ -48,11 +48,17 @@ via the virtual console or network interface.
 %files
 %license LICENSE
 %doc README.md
+%config(noreplace) %{_sysconfdir}/rshim.conf
 %{_sbindir}/rshim
 %{_unitdir}/rshim.service
 %{_mandir}/man8/rshim.8.gz
 
 %changelog
+* Fri Jul 24 2020 Liming Sun <lsun@mellanox.com> - 2.0.5-2
+- Add configuration file support
+- misc: Display device version / revision ID
+- Add service file for FreeBSD
+
 * Tue Jun 16 2020 Liming Sun <lsun@mellanox.com> - 2.0.5-1
 - Improve response time to ctrl+c for boot stream
 - Fix a rpmbuild issue when make_build is not defined

--- a/rshim.spec.in
+++ b/rshim.spec.in
@@ -4,7 +4,7 @@
 
 Name: rshim
 Version: @VERSION@
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: User-space driver for Mellanox BlueField SoC
 
 License: GPLv2
@@ -50,6 +50,8 @@ make
 %endif
 %{__install} -d %{buildroot}%{_mandir}/man8
 %{__install} -m 0644 man/rshim.8 %{buildroot}%{_mandir}/man8
+%{__install} -d %{buildroot}%{_sysconfdir}
+%{__install} -m 0644 etc/rshim.conf %{buildroot}%{_sysconfdir}
 
 %post
 %if "%{with_systemd}" == "1"
@@ -69,6 +71,7 @@ make
 %license LICENSE
 %defattr(-,root,root,-)
 %doc README.md
+%config(noreplace) %{_sysconfdir}/rshim.conf
 %if "%{with_systemd}" == "1"
   %{_unitdir}/rshim.service
 %endif
@@ -76,6 +79,11 @@ make
 %{_mandir}/man8/rshim.8.gz
 
 %changelog
+* Fri Jul 24 2020 Liming Sun <lsun@mellanox.com> - 2.0.5-2
+- Add configuration file support
+- misc: Display device version / revision ID
+- Add service file for FreeBSD
+
 * Tue Jun 16 2020 Liming Sun <lsun@mellanox.com> - 2.0.5-1
 - Improve response time to ctrl+c for boot stream
 - Fix a rpmbuild issue when make_build is not defined


### PR DESCRIPTION
This commit adds configuration file support (/etc/rshim.conf)
which can be used to configure the static mapping of rshim
device to rshim name as well as the rshim devices to be ignored.

Signed-off-by: Liming Sun <lsun@mellanox.com>