### PR TITLE
Put livefish driver in drop mode by default

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -321,12 +321,9 @@ static ssize_t rshim_write_delayed(rshim_backend_t *bd, int devtype,
   time_t t0, t1;
   uint64_t reg;
 
-  if (bd->drop_mode)
-    return count;
-
   switch (devtype) {
   case RSH_DEV_TYPE_TMFIFO:
-    if (bd->is_boot_open)
+    if (bd->is_boot_open || bd->drop_mode)
       return count;
     size_addr = RSH_TM_HOST_TO_TILE_STS;
     size_mask = RSH_TM_HOST_TO_TILE_STS__COUNT_MASK;
@@ -605,7 +602,7 @@ int rshim_boot_open(rshim_backend_t *bd)
 
   pthread_mutex_lock(&bd->mutex);
 
-  if (bd->is_boot_open || bd->drop_mode) {
+  if (bd->is_boot_open) {
     RSHIM_INFO("can't boot, boot file already open\n");
     pthread_mutex_unlock(&bd->mutex);
     return -EBUSY;

--- a/src/rshim.h
+++ b/src/rshim.h
@@ -159,7 +159,8 @@ enum {
 
 #define RSH_BOOT_FIFO_SIZE   512
 
-#define LOCK_RETRY_CNT       100000
+/* Retry time in seconds. */
+#define RSHIM_LOCK_RETRY_TIME  2
 
 /* FIFO structure. */
 typedef struct {
@@ -508,5 +509,12 @@ int rshim_fuse_del(rshim_backend_t *bd);
 void rshim_fuse_input_notify(rshim_backend_t *bd);
 int rshim_fuse_got_peer_signal(void);
 #endif
+
+/* Allowed registers in drop mode. */
+static inline bool rshim_drop_mode_access(int addr)
+{
+  return (addr == RSH_BOOT_CONTROL || addr == RSH_RESET_CONTROL ||
+          addr == RSH_BOOT_FIFO_DATA || addr == RSH_BOOT_FIFO_COUNT);
+}
 
 #endif /* _RSHIM_H */

--- a/src/rshim_usb.c
+++ b/src/rshim_usb.c
@@ -260,6 +260,9 @@ static void rshim_usb_fifo_read(rshim_usb_t *dev, char *buffer, size_t count)
   struct libusb_transfer *urb;
   int rc;
 
+  if (!bd->has_rshim || !bd->has_tm || bd->drop_mode)
+    return;
+
   if ((int) *dev->intr_buf || bd->read_buf_bytes) {
     /* We're doing a read. */
     urb = dev->read_or_intr_urb;
@@ -392,6 +395,12 @@ static int rshim_usb_fifo_write(rshim_usb_t *dev, const char *buffer,
 {
   rshim_backend_t *bd = &dev->bd;
   int rc;
+
+  if (!bd->has_rshim || !bd->has_tm)
+    return -ENODEV;
+
+  if (bd->drop_mode)
+    return 0;
 
   if (count % 8)
     RSHIM_WARN("rshim write %d is not multiple of 8 bytes\n", (int)count);


### PR DESCRIPTION
This commit puts the livefish driver in drop mode by default to
avoid potential conflict with MFT tools. In such mode, only the
on-demand boot stream or reset command is allowed. All other read/
write requests will be ignored. This drop mode can be disabled by
sending command "DROP_MODE 0" to the misc file.

Signed-off-by: Liming Sun <lsun@mellanox.com>