### PR TITLE
Display/configure OPN string for BlueField-2

### DIFF
--- a/src/rshim.h
+++ b/src/rshim.h
@@ -162,6 +162,11 @@ enum {
 /* Retry time in seconds. */
 #define RSHIM_LOCK_RETRY_TIME  2
 
+/* YU boot record OPN offset/size */
+#define RSHIM_YU_BASE_ADDR             0x2800000
+#define RSHIM_YU_BOOT_RECORD_OPN       0xfd8
+#define RSHIM_YU_BOOT_RECORD_OPN_SIZE  16
+
 /* FIFO structure. */
 typedef struct {
   unsigned char *data;
@@ -516,5 +521,12 @@ static inline bool rshim_drop_mode_access(int addr)
   return (addr == RSH_BOOT_CONTROL || addr == RSH_RESET_CONTROL ||
           addr == RSH_BOOT_FIFO_DATA || addr == RSH_BOOT_FIFO_COUNT);
 }
+
+/*
+ * Get/Set the OPN string from the YU boot record, which means setting
+ * the value only persists during warm resets.
+ */
+int rshim_get_opn(rshim_backend_t *bd, char *opn, int len);
+int rshim_set_opn(rshim_backend_t *bd, const char *opn, int len);
 
 #endif /* _RSHIM_H */

--- a/src/rshim_pcie_lf.c
+++ b/src/rshim_pcie_lf.c
@@ -235,7 +235,7 @@ static int crspace_rsh_gw_write(struct pci_dev *pci_dev, int addr,
 /* Wait until the RSH_BYTE_ACC_CTL pending bit is cleared */
 static int rshim_byte_acc_pending_wait(struct pci_dev *pci_dev)
 {
-  uint32_t read_value;
+  uint32_t read_value = 0;
   time_t t0, t1;
   int rc;
 
@@ -256,7 +256,7 @@ static int rshim_byte_acc_pending_wait(struct pci_dev *pci_dev)
 /* Acquire BAW Interlock */
 static int rshim_byte_acc_lock_acquire(struct pci_dev *pci_dev)
 {
-  uint32_t read_value;
+  uint32_t read_value = 0;
   int rc;
   time_t t0, t1;
 


### PR DESCRIPTION
This commit supports the display and configuring of the OPN string
for BlueField-2 cards. The setting is in the YU boot record which
persists during warm reboot and will be lost after cold reboot.

Signed-off-by: Liming Sun <lsun@mellanox.com>