### PR TITLE
Fix return value if pcie or pcie_lf device not found

### DIFF
--- a/src/rshim_pcie.c
+++ b/src/rshim_pcie.c
@@ -529,6 +529,7 @@ int rshim_pcie_init(void)
   struct pci_access *pci;
   struct pci_dev *dev;
   int rc;
+  bool dev_present = false;
 
   pci = pci_alloc();
   if (!pci)
@@ -552,7 +553,11 @@ int rshim_pcie_init(void)
       continue;
 
     rshim_pcie_probe(dev);
+    dev_present = true;
   }
+
+  if (!dev_present)
+	  return -1;
 
   return 0;
 }

--- a/src/rshim_pcie_lf.c
+++ b/src/rshim_pcie_lf.c
@@ -594,6 +594,7 @@ int rshim_pcie_lf_init(void)
   struct pci_access *pci;
   struct pci_dev *dev;
   int rc;
+  bool dev_present = false;
 
   pci = pci_alloc();
   if (!pci)
@@ -616,7 +617,11 @@ int rshim_pcie_lf_init(void)
     if (rc)
       continue;
     rshim_pcie_probe(dev);
+    dev_present = true;
   }
+
+  if (!dev_present)
+	  return -1;
 
   return 0;
 }


### PR DESCRIPTION
If we are not able to find the pcie/pcie_lf device, we should return an error, so that rshim can catch that and abort.

Signed-off-by: Matthias Brugger <mbrugger@suse.com>