### PR TITLE
rshim_pcie: Fix a typo in mmap

### DIFF
--- a/src/rshim_pcie.c
+++ b/src/rshim_pcie.c
@@ -413,8 +413,8 @@ static int rshim_pcie_probe(struct pci_dev *pci_dev)
   }
 
   dev->rshim_regs = mmap(NULL, PCI_RSHIM_WINDOW_SIZE,
-                         PROT_READ | PROT_WRITE | MAP_LOCKED,
-                         MAP_SHARED, dev->pci_fd,
+                         PROT_READ | PROT_WRITE,
+                         MAP_SHARED | MAP_LOCKED, dev->pci_fd,
                          PCI_RSHIM_WINDOW_OFFSET);
   if (dev->rshim_regs == MAP_FAILED) {
     RSHIM_ERR("Failed to map RShim registers\n");


### PR DESCRIPTION
This commit fixes a typo in mmap where MAP_LOCKED should be
set in the 'flags' argument instead of the 'prot' argument
of mmap().

Signed-off-by: Liming Sun <lsun@mellanox.com>