### PR TITLE
Some robust fixes for USB rshim

### DIFF
--- a/src/rshim.h
+++ b/src/rshim.h
@@ -421,6 +421,7 @@ rshim_backend_t *rshim_find_by_dev(void *dev);
 
 /* RShim global lock. */
 void rshim_lock(void);
+int rshim_trylock(void);
 void rshim_unlock(void);
 
 /* Event notification. */

--- a/src/rshim_net.c
+++ b/src/rshim_net.c
@@ -81,7 +81,7 @@ static int rshim_if_open(char *ifname, int index)
   ifr.ifr_hwaddr.sa_family = ARPHRD_ETHER;
   ifr.ifr_hwaddr.sa_data[5] += index * 2;
   if (ioctl(fd, SIOCSIFHWADDR, &ifr)) {
-    perror("SIOCSIFHWADDR");
+    RSHIM_ERR("ioctl SIOCSIFHWADDR failed");
     close(fd);
     return -1;
   }
@@ -133,7 +133,7 @@ static int rshim_if_open(char *ifname, int index)
 
   memset(&ifr, 0, sizeof(ifr));
   if (ioctl(fd, TAPGIFNAME, &ifr) < 0) {
-    perror("TAPGIFNAME");
+    RSHIM_ERR("ioctl TAPGIFNAME failed");
     close(fd);
     close(s);
     return -1;
@@ -169,7 +169,7 @@ static int rshim_if_open(char *ifname, int index)
 
   ifr.ifr_mtu = ETH_PKT_SIZE;
   if (ioctl(s, SIOCSIFMTU, &ifr) < 0) {
-    perror("SIOCSIMTU");
+    RSHIM_ERR("ioctl SIOCSIMTU failed");
     close(s);
     close(fd);
     return -1;
@@ -180,7 +180,7 @@ static int rshim_if_open(char *ifname, int index)
   ifr.ifr_addr.sa_len = 6;
   ifr.ifr_addr.sa_data[5] += index * 2;
   if (ioctl(s, SIOCSIFLLADDR, &ifr) < 0) {
-    perror("SIOCSIFLLADDR");
+    RSHIM_ERR("ioctl SIOCSIFLLADDR failed");
     close(s);
     close(fd);
     return -1;
@@ -282,7 +282,7 @@ int rshim_net_init(rshim_backend_t *bd)
 
   rc = pipe(fd);
   if (rc == -1) {
-    perror("Failed to create pipe %m");
+    RSHIM_ERR("Failed to create net pipe");
     goto fail;
   }
 


### PR DESCRIPTION
This commit has the following robust fixes to solve issues found
on a setup with multiple USB rshim resetting in parallel.
1. rshim read might be not ready yet when USB is probed, which
   caused RSH_SCRATCHPAD1 read fail. Some retry was added in
   rshim_access_check().

2. Add more RSHIM_ERR() for error cases. Also change perror()
   to RSHIM_ERR(), so it could be logged in syslog.

3. rshim_usb_disconnect() could be trigger by the hotplug
   callback when USB is disconnected while doing synchronous
   read/write(). Add mutex trylock mechanism to avoid mutex
   deadlock. Later there will be another call to this function
   again to cleanup the backend.

Signed-off-by: Liming Sun <lsun@mellanox.com>