### PR TITLE
rshim.spec.in: Stop rshim service only if it was running

### DIFF
--- a/rshim.spec.in
+++ b/rshim.spec.in
@@ -55,7 +55,9 @@ make
 
 %pre
 %if "%{with_systemd}" == "1"
-  systemctl stop rshim
+  if systemctl is-active --quiet rshim ; then
+      systemctl stop rshim
+  fi
 %endif
 
 %post
@@ -68,7 +70,9 @@ make
 %preun
 if [ "$1" = "0" ]; then
 %if "%{with_systemd}" == "1"
-  systemctl stop rshim
+  if systemctl is-active --quiet rshim ; then
+      systemctl stop rshim
+  fi
 %else
   killall -9 rshim
 %endif


### PR DESCRIPTION
In case that the rshim server was not running, then installing the
new packages fails with error like:
  Failed to stop rshim.service: Unit rshim.service not loaded.
  error: %prein(rshim-2.0.5-4.x86_64) scriptlet failed, exit status 5
  error: rshim-2.0.5-4.x86_64: install failed

Fixes: 0f1a303d106a ("Auto-start rshim service after installation")
Signed-off-by: Alaa Hleihel <alaa@nvidia.com>