### PR TITLE
Enable console output during boot stream pushing

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -274,9 +274,6 @@ static ssize_t rshim_read_default(rshim_backend_t *bd, int devtype,
     return -EINVAL;
   }
 
-  if (bd->is_boot_open)
-    return 0;
-
   while (total < count) {
     if (avail == 0) {
       rc = bd->read_rshim(bd, RSHIM_CHANNEL, RSH_TM_TILE_TO_HOST_STS, &reg);
@@ -1033,7 +1030,7 @@ static void rshim_fifo_input(rshim_backend_t *bd)
   uint8_t rx_avail = 0;
   int rc;
 
-  if (bd->is_boot_open || !bd->has_rshim || !bd->has_tm)
+  if (!bd->has_rshim || !bd->has_tm)
     return;
 
 again:
@@ -1587,6 +1584,8 @@ static void rshim_work_handler(rshim_backend_t *bd)
   }
 
   if (bd->is_boot_open || bd->is_booting) {
+    if (bd->is_boot_open && bd->has_cons_work)
+      rshim_fifo_input(bd);
     pthread_mutex_unlock(&bd->mutex);
     return;
   }


### PR DESCRIPTION
This commit removes some checkings of the "is_boot_open" flag
so rshim console could display output when pushing the boot
stream.

Signed-off-by: Liming Sun <lsun@mellanox.com>