### PR TITLE
Add bfb-install script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,7 @@ SUBDIRS = src man
 dist_doc_DATA = README.md
 confdir = $(sysconfdir)
 dist_conf_DATA = etc/rshim.conf
+dist_sbin_SCRIPTS = scripts/bfb-install
 
 AM_DISTCHECK_CONFIGURE_FLAGS = \
   --with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir)

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -2,4 +2,4 @@
 # Copyright (C) 2019 Mellanox Technologies. All Rights Reserved.
 #
 
-man8_MANS = rshim.8
+man8_MANS = rshim.8 bfb-install.8

--- a/man/bfb-install.8
+++ b/man/bfb-install.8
@@ -1,0 +1,28 @@
+.\" Manpage for bfb-install.
+.TH man 8 "19 Nov 2020" "2.0" "bfb-install man page"
+.SH NAME
+bfb-install \- BFB installing script for BlueField SoC over rshim driver
+.SH SYNOPSIS
+rshim [options]
+.SH DESCRIPTION
+bfb-install is a utility script to install BFB images on BlueField SoC over the rshim driver.
+.SH OPTIONS
+-b, --bfb
+.in +4n
+This is the BFB image to use, which is pushed as the boot stream.
+.in
+
+-c, --config
+.in +4n
+This is an optional configuration file to use, usually called bf.cfg.
+.in
+
+-f, --rootfs
+.in +4n
+This is the optional rootfs tar.xz file which is uaually used when installing Yocto.
+.in
+
+-r, --rshim
+.in +4n
+This is the rshim device to use, which can be 'rshim<N>' or '/dev/rshim<N>'.
+.in

--- a/rshim.spec.in
+++ b/rshim.spec.in
@@ -50,8 +50,10 @@ make
 %endif
 %{__install} -d %{buildroot}%{_mandir}/man8
 %{__install} -m 0644 man/rshim.8 %{buildroot}%{_mandir}/man8
+%{__install} -m 0644 man/bfb-install.8 %{buildroot}%{_mandir}/man8
 %{__install} -d %{buildroot}%{_sysconfdir}
 %{__install} -m 0644 etc/rshim.conf %{buildroot}%{_sysconfdir}
+%{__install} -m 0755 scripts/bfb-install %{buildroot}%{_sbindir}
 
 %pre
 %if "%{with_systemd}" == "1"
@@ -88,7 +90,9 @@ fi
   %{_unitdir}/rshim.service
 %endif
 %{_sbindir}/rshim
+%{_sbindir}/bfb-install
 %{_mandir}/man8/rshim.8.gz
+%{_mandir}/man8/bfb-install.8.gz
 
 %changelog
 * Thu Oct 29 2020 Liming Sun <lsun@mellanox.com> - 2.0.5-5

--- a/scripts/bfb-install
+++ b/scripts/bfb-install
@@ -1,0 +1,143 @@
+#!/bin/sh
+
+# Copyright (c) 2020, NVIDIA Corporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+usage ()
+{
+  echo "syntax: bfb_install --bfb|-b <BFBFILE> [--config|-c <bf.cfg>] \\"
+  echo "  [--rootfs|-f <rootfs.tar.xz>] --rshim|-r <rshimN> [--help|-h]"
+}
+
+bfb=
+cfg=
+rootfs=
+rshim=
+
+options=`getopt -n bfb_install -o b:c:f:r:h \
+        -l help,bfb:,config:,rootfs:,rshim: -- "$@"`
+eval set -- $options
+while [ "$1" != -- ]; do
+  case $1 in
+    --help|-h) usage; exit 0 ;;
+    --bfb|-b) shift; bfb=$1 ;;
+    --config|-c) shift; cfg=$1 ;;
+    --rootfs|-f) shift; rootfs=$1 ;;
+    --rshim|-r) shift; rshim=$1 ;;
+  esac
+  shift
+done
+shift
+
+if [ $# -ne 0 ]; then
+  usage >&2
+  exit 1
+fi
+
+if [ -z "${bfb}" -o -z "${rshim}" ]; then
+  echo "Error: Need to provide both bfb file and rshim device name."
+  usage >&2
+  exit 1
+fi
+
+if [ ! -e "${bfb}" ]; then
+  echo "Error: ${bfb} not found."
+  exit 1
+fi
+
+if [ ."$(echo "${rshim}" | cut -c1-1)" != ."/" ]; then
+  rshim="/dev/${rshim}"
+fi
+
+if [ ! -e "${rshim}/boot" ]; then
+  echo "Error: ${rshim}/boot not found."
+  exit 1
+fi
+
+if [ -n "${rootfs}" -a ! -e "${rootfs}" ]; then
+  echo "Error: ${rootfs} not found."
+  exit 1
+fi
+
+if [ -n "${cfg}" -a ! -e "${cfg}" ]; then
+  echo "Error: ${cfg} not found."
+  exit 1
+fi
+
+if [ $(id -u) -ne 0 ]; then
+  echo "Error: Need root permission to push BFB on local host."
+  exit 1
+fi
+
+pv=$(which pv 2>/dev/null)
+if [ -z "${pv}" ]; then
+  echo "Warn: 'pv' command not found. Continue without showing BFB progress."
+fi
+
+# Push the boot stream.
+echo "Pushing bfb${cfg:+ + cfg}${rootfs:+ + rootfs}"
+sh -c "cat ${bfb} ${cfg:+$cfg} ${rootfs:+${rootfs}} ${pv:+| ${pv}} > ${rshim}/boot"
+
+# Print the rshim log.
+echo "Collecting BlueField booting status. Press Ctrl+C to stop…"
+
+last=""
+while true; do
+  last_len=${#last}
+  cur=$(echo 'DISPLAY_LEVEL 2' > ${rshim}/misc && cat ${rshim}/misc | sed -n '/^ INFO/,$p')
+  cur_len=${#cur}
+
+  sleep 1
+
+  # Overwrite if current length smaller than previous length.
+  if [ ${last_len} -eq 0 -o ${last_len} -gt ${cur_len} ]; then
+    echo "${cur}" | sed '/^[[:space:]]*$/d'
+    last="${cur}"
+    continue
+  fi
+
+  # Overwrite if first portion doesn't match.
+  sub_cur=$(echo "${cur}" | dd bs=1 count=${last_len} 2>/dev/null)
+  if [ "${sub_cur}" != "${last}" ]; then
+    echo "${cur}" | sed '/^[[:space:]]*$/d'
+    last="${cur}"
+    continue
+  fi
+
+  # Nothing if no update.
+  if [ ${last_len} -eq ${cur_len} ]; then
+    continue;
+  fi
+
+  # Print the diff.
+  echo "${cur}" | dd bs=1 skip=${last_len} 2>/dev/null | sed '/^[[:space:]]*$/d'
+  last="${cur}"
+
+  if echo ${cur} | grep -i "Reboot" >/dev/null; then
+    break;
+  fi
+done


### PR DESCRIPTION
This commit adds the bfb-install script for BFB install and status check.

Below is an example of command and output.
bfb-install --rshim rshim0 --bfb install.bfb --rootfs rootfs.tar.xz \
  --config bf.cfg
Pushing bfb + cfg + rootfs
 896MiB 0:09:12 [1.62MiB/s] [                    <=>          ]
Collecting BlueField booting status. Press Ctrl+C to stop…
 INFO[BL2]: start
 INFO[BL2]: no DDR on MSS0
 INFO[BL2]: DDR POST passed
 INFO[BL2]: UEFI loaded
 INFO[BL31]: start
 INFO[BL31]: runtime
 INFO[UEFI]: eMMC init
 INFO[UEFI]: eMMC probed
 INFO[MISC]: Found bf.cfg
 INFO[MISC]: Found tarball
 INFO[MISC]: Start decomp
 INFO[MISC]: Start install
 INFO[MISC]: Rebooting

Signed-off-by: Liming Sun <limings@nvidia.com>