### PR TITLE
Ignore rshim access checking when global drop mode is enabled

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -2199,6 +2199,9 @@ int rshim_register(rshim_backend_t *bd)
     return -EINVAL;
   }
 
+  if (rshim_drop_mode >= 0)
+    bd->drop_mode = rshim_drop_mode;
+
   rc = rshim_access_check(bd);
   if (rc)
     return rc;
@@ -2252,8 +2255,6 @@ int rshim_register(rshim_backend_t *bd)
   bd->registered = 1;
   bd->boot_timeout = rshim_boot_timeout;
   bd->display_level = rshim_display_level;
-  if (rshim_drop_mode >= 0)
-    bd->drop_mode = rshim_drop_mode;
 
   /* Start the keepalive timer. */
   bd->last_keepalive = rshim_timer_ticks;

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -841,12 +841,14 @@ static int rshim_fuse_misc_write(struct cuse_dev *cdev, int fflags,
      * same rshim device before enabling it.
      */
     if (old_value && !bd->drop_mode) {
+      rshim_lock();
       pthread_mutex_lock(&bd->mutex);
       if (rshim_access_check(bd)) {
         RSHIM_WARN("rshim %s is not accessible\n", bd->dev_name);
         bd->drop_mode = old_value;
       }
       pthread_mutex_unlock(&bd->mutex);
+      rshim_unlock();
     }
   } else if (strcmp(key, "BOOT_MODE") == 0) {
     if (sscanf(p, "%x", &value) != 1)

--- a/src/rshim_pcie.c
+++ b/src/rshim_pcie.c
@@ -495,14 +495,16 @@ int rshim_pcie_enable(void *dev, bool enable)
   DIR* dir;
 
   /* Check whether it's being attached by other driver. */
-  snprintf(path, sizeof(path), "%s/%04x:%02x:%02x.%1u/driver",
-           SYS_BUS_PCI, pci_dev->domain, pci_dev->bus,
-           pci_dev->dev, pci_dev->func);
-  dir = opendir(path);
-  if (dir) {
-    RSHIM_ERR("failed to open %s\n", path);
-    closedir(dir);
-    return -EBUSY;
+  if (!rshim_drop_mode) {
+    snprintf(path, sizeof(path), "%s/%04x:%02x:%02x.%1u/driver",
+             SYS_BUS_PCI, pci_dev->domain, pci_dev->bus,
+             pci_dev->dev, pci_dev->func);
+    dir = opendir(path);
+    if (dir) {
+      RSHIM_ERR("rshim used by %s\n", path);
+      closedir(dir);
+      return -EBUSY;
+    }
   }
 
   /* Set the enable attribute in sysfs. */


### PR DESCRIPTION
This commit ignores the rshim access checking when global drop mode
is enabled in /etc/rshim.conf. It's requested for certain scenarios
where the rshim devices need to be visible in hypervisor when
drop_mode is enabled, at the same time it's pass-throughed to VM.
When drop_mode is globally enabled, it's user's responsibility to
make sure no parallel access from USB and PCIe to the same rshim.

Signed-off-by: Liming Sun <limings@nvidia.com>