### PR TITLE
Don't allow any register access when DROP_MODE is set

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -640,6 +640,12 @@ int rshim_boot_open(rshim_backend_t *bd)
 
   pthread_mutex_lock(&bd->mutex);
 
+  if (bd->drop_mode) {
+    RSHIM_INFO("rshim is in drop mode\n");
+    pthread_mutex_unlock(&bd->mutex);
+    return -EINVAL;
+  }
+
   if (bd->is_boot_open) {
     RSHIM_INFO("can't boot, boot file already open\n");
     pthread_mutex_unlock(&bd->mutex);

--- a/src/rshim.h
+++ b/src/rshim.h
@@ -532,13 +532,6 @@ void rshim_fuse_input_notify(rshim_backend_t *bd);
 int rshim_fuse_got_peer_signal(void);
 #endif
 
-/* Allowed registers in drop mode. */
-static inline bool rshim_drop_mode_access(int addr)
-{
-  return (addr == RSH_BOOT_CONTROL || addr == RSH_RESET_CONTROL ||
-          addr == RSH_BOOT_FIFO_DATA || addr == RSH_BOOT_FIFO_COUNT);
-}
-
 /*
  * Get/Set the OPN string from the YU boot record, which means setting
  * the value only persists during warm resets.

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -828,6 +828,7 @@ static int rshim_fuse_misc_write(struct cuse_dev *cdev, int fflags,
   } else if (strcmp(key, "DROP_MODE") == 0) {
     if (sscanf(p, "%d", &value) != 1)
       goto invalid;
+    pthread_mutex_lock(&bd->mutex);
     old_value = (int)bd->drop_mode;
     bd->drop_mode = !!value;
     if (bd->drop_mode)
@@ -836,6 +837,7 @@ static int rshim_fuse_misc_write(struct cuse_dev *cdev, int fflags,
       if (bd->enable_device(bd, true))
         bd->drop_mode = 1;
     }
+    pthread_mutex_unlock(&bd->mutex);
     /*
      * Check if another endpoint driver has already attached to the
      * same rshim device before enabling it.

--- a/src/rshim_pcie.c
+++ b/src/rshim_pcie.c
@@ -262,7 +262,7 @@ rshim_pcie_read(rshim_backend_t *bd, int chan, int addr, uint64_t *result)
   if (!bd->has_rshim || !bd->has_tm)
     return -ENODEV;
 
-  if (bd->drop_mode && !rshim_drop_mode_access(addr)) {
+  if (bd->drop_mode) {
     *result = 0;
     return 0;
   }
@@ -288,7 +288,7 @@ rshim_pcie_write(rshim_backend_t *bd, int chan, int addr, uint64_t value)
   if (!bd->has_rshim || !bd->has_tm)
     return -ENODEV;
 
-  if (bd->drop_mode && !rshim_drop_mode_access(addr))
+  if (bd->drop_mode)
     return 0;
 
   /*

--- a/src/rshim_pcie_lf.c
+++ b/src/rshim_pcie_lf.c
@@ -431,7 +431,7 @@ rshim_pcie_read(struct rshim_backend *bd, int chan, int addr, uint64_t *result)
   if (!bd->has_rshim || !bd->has_tm)
     return -ENODEV;
 
-  if (bd->drop_mode && !rshim_drop_mode_access(addr)) {
+  if (bd->drop_mode) {
     *result = 0;
     return 0;
   }
@@ -455,7 +455,7 @@ rshim_pcie_write(struct rshim_backend *bd, int chan, int addr, uint64_t value)
   if (!bd->has_rshim || !bd->has_tm)
     return -ENODEV;
 
-  if (bd->drop_mode && !rshim_drop_mode_access(addr))
+  if (bd->drop_mode)
     return 0;
 
   /*


### PR DESCRIPTION
DROP_MODE was added for live-fish mode, but turned out to be used
for other cases as well. Previously, some operations like pushing
boot stream is allowed in DROP mode, which is probmatic. For example,
it writes to the boot fifo, but the reading of scratch register does
nothing which causes potential boot fifo overflow for pcie rshim. This
commit disables all register access for pcie/pcie_lf for simplicity.

Signed-off-by: Liming Sun <limings@nvidia.com>