### PR TITLE
Add workaround checking for Bluefield-2 REV-0

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -2129,7 +2129,9 @@ int rshim_access_check(rshim_backend_t *bd)
 
   rshim_boot_workaround_check(bd);
 
-  if (bd->ver_id == RSHIM_BLUEFIELD_2 && rshim_is_livefish(bd)) {
+  /* BLUEFIELD_2 REV0 workaround. */
+  if (bd->ver_id == RSHIM_BLUEFIELD_2 && bd->rev_id == BLUEFIELD_REV0 &&
+      rshim_is_livefish(bd)) {
     if (rshim_bf2_a0_wa(bd) != 0) {
       /*
        * If the workaround fails it is likely because the mesh is already

--- a/src/rshim.h
+++ b/src/rshim.h
@@ -204,6 +204,10 @@ typedef struct {
 #define RSHIM_BLUEFIELD_1 1
 #define RSHIM_BLUEFIELD_2 2
 
+/* Bluefield Revision ID. */
+#define BLUEFIELD_REV0 0
+#define BLUEFIELD_REV1 1
+
 /* RShim backend. */
 typedef struct rshim_backend rshim_backend_t;
 struct rshim_backend {


### PR DESCRIPTION
This commit adds the workaround checking for Bluefield-2 REV-0, so the
workaround is only applied for A0 card. Or else it might think the card
is in livefish mode and cause infinite rebooting when due to mmio read
always returns 0 in secure boot mode.

Signed-off-by: Liming Sun <limings@nvidia.com>