### PR TITLE
Fix 5a174a13d559 for potential USB deadlock

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -1285,7 +1285,10 @@ static void rshim_fifo_output(rshim_backend_t *bd)
   if (bd->spin_flags & RSH_SFLG_WRITING)
     return;
 
-  fifo_avail = rshim_fifo_tx_avail(bd) * sizeof(uint64_t);
+  if (bd->has_reprobe)
+    fifo_avail = WRITE_BUF_SIZE;
+  else
+    fifo_avail = rshim_fifo_tx_avail(bd) * sizeof(uint64_t);
   write_avail = fifo_avail - write_buf_next;
 
   if (!bd->write_buf_pkt_rem) {


### PR DESCRIPTION
This commit has a fix for 5a174a13d559 to make it only applicable
for rshim/pcie. Commit 5a174a13d559 is supposed to fix an issue for
rshim/pcie and is not needed for USB. For USB, it's protected by the
RSH_SFLG_WRITING flag so only one read/write packet could be pending.
That commit also has side effect for USB that the rshim_fifo_tx_avail()
function could trigger USB read/write callback which try to take the
bd->ringlock again and caused potential dead-lock.

Signed-off-by: Liming Sun <limings@nvidia.com>