### PR TITLE
Several fixes to prevent hypervisor crash

### DIFF
--- a/src/rshim_net.c
+++ b/src/rshim_net.c
@@ -346,6 +346,11 @@ void rshim_net_rx(rshim_backend_t *bd)
     }
 
     total_len = ntohs(pkt->hdr.len) + sizeof(pkt->hdr);
+    /* Drop invalid data. */
+    if (total_len > sizeof(*pkt)) {
+      bd->net_rx_len = 0;
+      continue;
+    }
     while (bd->net_rx_len < total_len) {
       len = rshim_fifo_read(bd, (char *)pkt + bd->net_rx_len,
                             total_len - bd->net_rx_len,


### PR DESCRIPTION
This commit has some fixes to prevent intermittent hypervisor crash
when multiple cards reboot or push boot stream in parallel.

- Fix the return logic in rshim_is_livefish();
- Move the sleep inside rshim_boot_open() to prevent immediate
  rshim access after SW reset and semaphore release;
- Clean up some log messages;
- Add a robust fix in rshim_net_rx() to drop error packets;

This commit fixes the return logic in rshim_is_livefish().

Signed-off-by: Liming Sun <limings@nvidia.com>