### PR TITLE
Make the reset delay configurable

### DIFF
--- a/etc/rshim.conf
+++ b/etc/rshim.conf
@@ -8,6 +8,8 @@
 #DISPLAY_LEVEL 0
 #BOOT_TIMEOUT  100
 #DROP_MODE     0
+#USB_RESET_DELAY  3
+#PCIE_RESET_DELAY 10
 
 #
 # Static mapping of rshim name and device.

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -183,6 +183,8 @@ const char *rshim_cfg_file = DEFAULT_RSHIM_CONFIG_FILE;
 static int rshim_display_level = 0;
 static int rshim_boot_timeout = 100;
 int rshim_drop_mode = -1;
+int rshim_usb_reset_delay = 3;
+int rshim_pcie_reset_delay = 10;
 
 /* Array of devices and device names. */
 rshim_backend_t *rshim_devs[RSHIM_MAX_DEV];
@@ -748,7 +750,7 @@ int rshim_boot_open(rshim_backend_t *bd)
 boot_open_done:
 
   /* Add a small delay for the reset. */
-  sleep(!bd->has_reprobe ? 10 : 1);
+  sleep(!bd->has_reprobe ? rshim_pcie_reset_delay : rshim_usb_reset_delay);
 
   rshim_ref(bd);
   pthread_mutex_unlock(&bd->mutex);
@@ -2677,6 +2679,12 @@ static int rshim_load_cfg(void)
       continue;
     } else if (!strcmp(key, "DROP_MODE")) {
       rshim_drop_mode = atoi(value);
+      continue;
+    } else if (!strcmp(key, "PCIE_RESET_DELAY")) {
+      rshim_pcie_reset_delay = atoi(value);
+      continue;
+    } else if (!strcmp(key, "USB_RESET_DELAY")) {
+      rshim_usb_reset_delay = atoi(value);
       continue;
     }
 

--- a/src/rshim.h
+++ b/src/rshim.h
@@ -40,6 +40,8 @@
 extern int rshim_log_level;
 extern bool rshim_daemon_mode;
 extern int rshim_drop_mode;
+extern int rshim_usb_reset_delay;
+extern int rshim_pcie_reset_delay;
 
 #ifndef offsetof
 #define offsetof(TYPE, MEMBER)	((size_t)&((TYPE *)0)->MEMBER)

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -883,7 +883,7 @@ static int rshim_fuse_misc_write(struct cuse_dev *cdev, int fflags,
 
       if (!bd->has_reprobe) {
         /* Attach. */
-        sleep(10);
+        sleep(rshim_pcie_reset_delay);
         pthread_mutex_lock(&bd->mutex);
         bd->is_booting = 0;
         rshim_notify(bd, RSH_EVENT_ATTACH, 0);


### PR DESCRIPTION
This commit makes the reset delay configurable instead of
hard-coded value. It also updates the USB reset delay to 3 seconds
to workaround some issue seen with USB hub.

Signed-off-by: Liming Sun <limings@nvidia.com>