### PR TITLE
Support RSHIM USB for Mustang

### DIFF
--- a/src/rshim.h
+++ b/src/rshim.h
@@ -93,6 +93,8 @@ extern int rshim_pcie_reset_delay;
 #define WRITE_FIFO_SIZE   (4 * 1024)
 #define BOOT_BUF_SIZE     (16 * 1024)
 
+#define BF3_MAX_BOOT_FIFO_SIZE 8192 /* bytes */
+
 /* Sub-device types. */
 enum {
   RSH_DEV_TYPE_RSHIM,


### PR DESCRIPTION
1) Modify rshim usb boot fifo code to take into account
   BOOT FIFO COUNT. Only send a bulk transfer if there
   is enough space in the boot fifo.
   Note that there are instances where even if the BOOT
   FIFO is empty, the number of bytes to be written can be
   greater than the max available space in the BOOT FIFO.
   For example, the write requests 0x4000 bytes while the
   BOOT FIFO size is 0x2000.
2) Modify rshim usb tmfifo in code to take into account
   the exact number of bytes to be sent by HW. get the
   value from the interrupt transfer and pass it to
   the bulk in transfer.