### PR TITLE
Add interrupt polling for direct mmap() mode

### DIFF
--- a/etc/rshim.conf
+++ b/etc/rshim.conf
@@ -10,6 +10,7 @@
 #DROP_MODE     0
 #USB_RESET_DELAY  3
 #PCIE_RESET_DELAY 10
+#PCIE_INTR_POLL_INTERVAL 10
 
 #
 # Static mapping of rshim name and device.

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -2719,6 +2719,9 @@ static int rshim_load_cfg(void)
     } else if (!strcmp(key, "USB_RESET_DELAY")) {
       rshim_usb_reset_delay = atoi(value);
       continue;
+    } else if (!strcmp(key, "PCIE_INTR_POLL_INTERVAL")) {
+      rshim_pcie_intr_poll_interval = atoi(value);
+      continue;
     }
 
     if (strncmp(key, "rshim", 5) && strcmp(key, "none"))

--- a/src/rshim.h
+++ b/src/rshim.h
@@ -42,6 +42,7 @@ extern bool rshim_daemon_mode;
 extern int rshim_drop_mode;
 extern int rshim_usb_reset_delay;
 extern int rshim_pcie_reset_delay;
+extern int rshim_pcie_intr_poll_interval;
 
 #ifndef offsetof
 #define offsetof(TYPE, MEMBER)	((size_t)&((TYPE *)0)->MEMBER)


### PR DESCRIPTION
This commit adds interrupt polling for direct mmap() mode. Without
it the mlxfwreset sync-1 mode would fail due to FW waiting for the
interrupt ACK when rshim works in direct mmap() mode.

Signed-off-by: Liming Sun <limings@nvidia.com>