### PR TITLE
Detect new USB/rshim hot plugin

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -2612,9 +2612,6 @@ static void rshim_main(int argc, char *argv[])
       }
     }
 
-    /* Check USB for timeout or unhandled fd. */
-    rshim_usb_poll();
-
     /* Delayed initialization for livefish probe. */
     if (!rshim_pcie_lf_init_done) {
       time(&t1);
@@ -2631,6 +2628,9 @@ static void rshim_main(int argc, char *argv[])
       } else if (rshim_timer_interval) {
           rshim_set_timer(timer_fd, 0);
       }
+
+      /* Check USB for timeout or unhandled fd. */
+      rshim_usb_poll(rshim_dev_bitmask ? false : true);
     }
   }
 

--- a/src/rshim.h
+++ b/src/rshim.h
@@ -549,14 +549,15 @@ bool rshim_allow_device(const char *devname);
 /* USB backend APIs. */
 #ifdef HAVE_RSHIM_USB
 int rshim_usb_init(int epoll_fd);
-void rshim_usb_poll(void);
+void rshim_usb_poll(bool blocking);
 #else
 static inline int rshim_usb_init(int epoll_fd)
 {
   return -1;
 }
-static inline void rshim_usb_poll(void)
+static inline void rshim_usb_poll(bool blocking)
 {
+  (void)blocking;
 }
 #endif
 


### PR DESCRIPTION
This commit enables USB probing even there is no USB/rshim devices.
In such case, blocking call is used to avoid polling.

Signed-off-by: Liming Sun <limings@nvidia.com>