### PR TITLE
Avoid kernel-modules-extra dependency on ctyunos

### DIFF
--- a/rshim.spec.in
+++ b/rshim.spec.in
@@ -15,7 +15,7 @@ Source0: https://github.com/mellanox/rshim-user-space/archive/%{name}-%{version}
 BuildRequires: gcc, autoconf, automake, pkgconfig, make
 BuildRequires: pkgconfig(libpci), pkgconfig(libusb-1.0), pkgconfig(fuse)
 
-%if 0%{?rhel} >= 8 || 0%{?fedora} > 0
+%if (0%{?rhel} >= 8 || 0%{?fedora} > 0) && "0%{?ctyunos}" == "0"
 Requires: kernel-modules-extra
 %endif
 


### PR DESCRIPTION
In RHEL >= 8 systems, the fuse module is included in the package
kernel-modules-extra. ctyunos is somewhat of a RHEL8 clone, but includes
that module in the main kernel package. It does not have a
kernel-modules-extra package at all.

Signed-off-by: Tzafrir Cohen <nvidia@cohens.org.il>