### PR TITLE
BF3: Support 32-bit CR-space access via USB

### DIFF
--- a/src/rshim_usb.c
+++ b/src/rshim_usb.c
@@ -140,8 +140,13 @@ static struct rshim_usb_addr get_wvalue_windex(int chan, int addr, uint16_t ver_
   struct rshim_usb_addr rsh_usb_addr;
 
   if (ver_id == RSHIM_BLUEFIELD_3) {
-    rsh_usb_addr.wvalue = bf3_wvalue_widx_pair_map[chan].wvalue + BF_MMIO_BASE;
-    rsh_usb_addr.windex = bf3_wvalue_widx_pair_map[chan].windex + addr;
+    if (chan <= 0xF) {
+      rsh_usb_addr.wvalue = bf3_wvalue_widx_pair_map[chan].wvalue + BF_MMIO_BASE;
+      rsh_usb_addr.windex = bf3_wvalue_widx_pair_map[chan].windex + addr;
+    } else {
+      rsh_usb_addr.wvalue = chan;
+      rsh_usb_addr.windex = addr;
+    }
   } else {
     rsh_usb_addr.wvalue = chan;
     rsh_usb_addr.windex = addr;


### PR DESCRIPTION
This commit enhances the channel/address to access the 32-bit
CR-space via USB for BF3. When channel is bigger than 0xF, it'll
be interpreted as upper 16-bits of the linear CR-space address.

Signed-off-by: Liming Sun <limings@nvidia.com>