### PR TITLE
Add configuration option to enable/disable PCIe VFIO/UIO

### DIFF
--- a/etc/rshim.conf
+++ b/etc/rshim.conf
@@ -11,6 +11,8 @@
 #USB_RESET_DELAY  3
 #PCIE_RESET_DELAY 10
 #PCIE_INTR_POLL_INTERVAL 10
+#PCIE_HAS_VFIO 1
+#PCIE_HAS_UIO  1
 
 #
 # Static mapping of rshim name and device.

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -188,6 +188,9 @@ static int rshim_boot_timeout = 100;
 int rshim_drop_mode = -1;
 int rshim_usb_reset_delay = 5;
 int rshim_pcie_reset_delay = 10;
+int rshim_pcie_enable_vfio = 1;
+int rshim_pcie_enable_uio = 1;
+int rshim_pcie_intr_poll_interval = 10;  /* Interrupt polling in milliseconds */
 
 /* Array of devices and device names. */
 rshim_backend_t *rshim_devs[RSHIM_MAX_DEV];
@@ -2725,17 +2728,21 @@ static int rshim_load_cfg(void)
     } else if (!strcmp(key, "DROP_MODE")) {
       rshim_drop_mode = (atoi(value) > 0) ? 1 : 0;
       continue;
-    } else if (!strcmp(key, "PCIE_RESET_DELAY")) {
-      rshim_pcie_reset_delay = atoi(value);
-      continue;
     } else if (!strcmp(key, "USB_RESET_DELAY")) {
       rshim_usb_reset_delay = atoi(value);
       continue;
-#ifdef HAVE_RSHIM_PCIE
+    } else if (!strcmp(key, "PCIE_RESET_DELAY")) {
+      rshim_pcie_reset_delay = atoi(value);
+      continue;
     } else if (!strcmp(key, "PCIE_INTR_POLL_INTERVAL")) {
       rshim_pcie_intr_poll_interval = atoi(value);
       continue;
-#endif
+    } else if (!strcmp(key, "PCIE_HAS_VFIO")) {
+      rshim_pcie_enable_vfio = atoi(value);
+      continue;
+    } else if (!strcmp(key, "PCIE_HAS_UIO")) {
+      rshim_pcie_enable_uio = atoi(value);
+      continue;
     }
 
     if (strncmp(key, "rshim", 5) && strcmp(key, "none"))

--- a/src/rshim.h
+++ b/src/rshim.h
@@ -43,6 +43,8 @@ extern int rshim_drop_mode;
 extern int rshim_usb_reset_delay;
 extern int rshim_pcie_reset_delay;
 extern int rshim_pcie_intr_poll_interval;
+extern int rshim_pcie_enable_vfio;
+extern int rshim_pcie_enable_uio;
 
 #ifndef offsetof
 #define offsetof(TYPE, MEMBER)	((size_t)&((TYPE *)0)->MEMBER)

--- a/src/rshim_pcie.c
+++ b/src/rshim_pcie.c
@@ -130,9 +130,6 @@ static const char *rshim_sys_pci_path;
 static bool rshim_pcie_has_uio(void);
 #endif
 
-/* Interrupt polling interval in milliseconds for direct-mapping mode. */
-int rshim_pcie_intr_poll_interval = 10;
-
 static inline uint64_t
 readq(const volatile void *addr)
 {
@@ -1094,6 +1091,9 @@ static bool rshim_pcie_has_vfio(void)
   DIR* dir;
   int rc;
 
+  if (!rshim_pcie_enable_vfio)
+    return false;
+
   rc = system("modprobe vfio_pci");
   if (rc == -1)
     RSHIM_DBG("Failed to load the vfio_pci module %m\n");
@@ -1118,6 +1118,9 @@ static bool rshim_pcie_has_uio(void)
 {
   DIR* dir;
   int rc;
+
+  if (!rshim_pcie_enable_uio)
+    return false;
 
   rc = system("modprobe uio_pci_generic");
   if (rc == -1)


### PR DESCRIPTION
VFIO/UIO is currently enabled by default and will be selected
automatically. Some users would like to specify which one to use
or diable. This commit adds configuration option in rshim.conf
to disable them as needed by setting PCIE_HAS_VFIO / PCIE_HAS_UIO
to 0 in rshim.conf.

Signed-off-by: Liming Sun <limings@nvidia.com>