### PR TITLE
Avoid potential race when stopping the rshim process

### DIFF
--- a/src/rshim_pcie.c
+++ b/src/rshim_pcie.c
@@ -223,11 +223,14 @@ static int rshim_pcie_enable_irq(rshim_pcie_t *dev, bool enable);
 /* Release pcie resource. */
 static void rshim_pcie_mmap_release(rshim_pcie_t *dev)
 {
+  volatile void *ptr;
   rshim_pcie_enable_irq(dev, false);
 
-  if (dev->rshim_regs) {
-    munmap((void *)dev->rshim_regs, PCI_RSHIM_WINDOW_SIZE);
+  ptr = dev->rshim_regs;
+  if (ptr) {
     dev->rshim_regs = NULL;
+    __sync_synchronize();
+    munmap((void *)ptr, PCI_RSHIM_WINDOW_SIZE);
   }
 
   if (dev->device_fd >= 0) {
@@ -841,7 +844,7 @@ rshim_pcie_read(rshim_backend_t *bd, int chan, int addr, uint64_t *result, int s
   rshim_pcie_t *dev = container_of(bd, rshim_pcie_t, bd);
   int rc = 0;
 
-  if (!bd->has_rshim || !bd->has_tm)
+  if (!bd->has_rshim || !bd->has_tm || !dev->rshim_regs)
     return -ENODEV;
 
   if (dev->nic_reset && addr != bd->regs->scratchpad6)
@@ -871,7 +874,7 @@ rshim_pcie_write(rshim_backend_t *bd, int chan, int addr, uint64_t value, int si
   uint64_t result;
   int rc = 0;
 
-  if (!bd->has_rshim || !bd->has_tm)
+  if (!bd->has_rshim || !bd->has_tm || !dev->rshim_regs)
     return -ENODEV;
 
   if (dev->nic_reset && addr != bd->regs->scratchpad6)
@@ -1046,7 +1049,9 @@ static int rshim_pcie_probe(struct pci_dev *pci_dev)
 
   /* Enable the device and setup memory map. */
   if (!bd->drop_mode) {
+    pthread_mutex_lock(&bd->mutex);
     rc = bd->enable_device(bd, true);
+    pthread_mutex_unlock(&bd->mutex);
     if (rc)
       goto rshim_probe_failed;
   }


### PR DESCRIPTION
This commit adds some robust check to avoid the race of the rshim_regs
pointer acess when stopping the process, which was found by restarting
the rshim service in a loop.

Signed-off-by: Liming Sun <limings@nvidia.com>