### PR TITLE
Adjust default boot timeout to 150s

### DIFF
--- a/etc/rshim.conf
+++ b/etc/rshim.conf
@@ -6,7 +6,7 @@
 # Default configuration for a rshim device
 #
 #DISPLAY_LEVEL 0
-#BOOT_TIMEOUT  100
+#BOOT_TIMEOUT  150
 #DROP_MODE     0
 #USB_RESET_DELAY  3
 #PCIE_RESET_DELAY 10

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -184,7 +184,7 @@ char *rshim_static_dev_name;
 /* Default configuration file. */
 const char *rshim_cfg_file = DEFAULT_RSHIM_CONFIG_FILE;
 static int rshim_display_level = 0;
-static int rshim_boot_timeout = 100;
+static int rshim_boot_timeout = 150;
 int rshim_drop_mode = -1;
 int rshim_usb_reset_delay = 5;
 int rshim_pcie_reset_delay = 10;


### PR DESCRIPTION
The 'BOOT_TIMEOUT' configuration parameter is used to detect ARM stuck/crash that it hasn't polled the boot fifo for such time. It's reported that when redfish is enabled it could take more than 100s doing something without reading the boot stream. Adjust the default value to avoid the false error.

Signed-off-by: Liming Sun <limings@nvidia.com>