### PR TITLE
Fix a potential NULL pointer access during USB disonnect

### DIFF
--- a/src/rshim_usb.c
+++ b/src/rshim_usb.c
@@ -662,12 +662,18 @@ static void rshim_usb_backend_cancel_req(rshim_backend_t *bd, int devtype,
 {
   rshim_usb_t *dev = container_of(bd, rshim_usb_t, bd);
 
+  if (!dev->handle)
+    return;
+
   switch (devtype) {
   case RSH_DEV_TYPE_TMFIFO:
-    if (is_write)
-      libusb_cancel_transfer(dev->write_urb);
-    else
-      libusb_cancel_transfer(dev->read_or_intr_urb);
+    if (is_write) {
+      if (dev->write_urb)
+        libusb_cancel_transfer(dev->write_urb);
+    } else {
+      if (dev->read_or_intr_urb)
+        libusb_cancel_transfer(dev->read_or_intr_urb);
+    }
     break;
 
   default:


### PR DESCRIPTION
Function rshim_usb_disconnect() will be called during USB disconnect which releases some buffer pointers, while rshim_usb_backend_cancel_req() is called during console release which tries to use these pointers. So it'll cause crash if console is released after USB disconnect and before the reconnect. This commit adds a check to avoid such issue.

Signed-off-by: Liming Sun <limings@nvidia.com>