### PR TITLE
rshim-pcie: add a new bad-access code

### DIFF
--- a/src/rshim.h
+++ b/src/rshim.h
@@ -98,7 +98,8 @@ extern int rshim_pcie_enable_uio;
 
 #define BF3_MAX_BOOT_FIFO_SIZE 8192 /* bytes */
 
-#define RSHIM_BAD_CTRL_REG(v) (((v) == 0xbad00acce55) || ((v) == (uint64_t)-1))
+#define RSHIM_BAD_CTRL_REG(v) \
+  (((v) == 0xbad00acce55) || ((v) == (uint64_t)-1) || ((v) == 0xbadacce55))
 
 /* Sub-device types. */
 enum {


### PR DESCRIPTION
This commit adds a new bad-access code detected recently so rshim driver could detect the failure to avoid stuck in loops.

Signed-off-by: Liming Sun <limings@nvidia.com>