### PR TITLE
Add dependency of libfuse2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 9), autotools-dev, pkg-config, libpci-dev, libusb-1
 Standards-Version: 4.1.4
 
 Package: rshim
-Depends: ${misc:Depends}
+Depends: ${misc:Depends}, libfuse2
 Architecture: any
 Homepage: https://github.com/Mellanox/rshim-user-space
 Description: driver for Mellanox BlueField SoC


### PR DESCRIPTION
This commit adds the libfuse2 dependency so it could be installed together with the driver. This issue was found when installing rshim driver on Ubuntu 22.04.

Signed-off-by: Liming Sun <limings@nvidia.com>