### PR TITLE
BF3: Support 4B access for PCIe

### DIFF
--- a/src/rshim.h
+++ b/src/rshim.h
@@ -184,6 +184,7 @@ enum {
 #define RSHIM_YU_BASE_ADDR             0x2800000
 #define RSHIM_YU_BOOT_RECORD_OPN       0xfd8
 #define RSHIM_YU_BOOT_RECORD_OPN_SIZE  16
+#define RSHIM_YU_BF3_BOOT_RECORD_OPN   0x9bdc
 
 #define YU_RESET_MODE_TRIGGER   0x0011
 #define YU_BOOT_DEVID           0x0014
@@ -415,11 +416,11 @@ struct rshim_backend {
   void (*destroy)(rshim_backend_t *bd);
 
   /* API to read <size> bytes from RShim. */
-  int (*read_rshim)(rshim_backend_t *bd, int chan, int addr,
+  int (*read_rshim)(rshim_backend_t *bd, uint32_t chan, uint32_t addr,
                     uint64_t *value, int size);
 
   /* API to write <size> bytes to RShim. */
-  int (*write_rshim)(rshim_backend_t *bd, int chan, int addr,
+  int (*write_rshim)(rshim_backend_t *bd, uint32_t chan, uint32_t addr,
                      uint64_t value, int size);
 
   /* API to enable the device. */

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -1116,9 +1116,8 @@ static void rshim_fuse_rshim_ioctl(fuse_req_t req, int cmd, void *arg,
      */
     chan = msg2.addr >> 16;
     offset = msg2.addr & 0xFFFF;
-    if (bd->ver_id <= RSHIM_BLUEFIELD_2 || strncmp(bd->dev_name, "usb", 3)) {
+    if (bd->ver_id <= RSHIM_BLUEFIELD_2)
       chan &= 0xF;
-    }
 
     if (cmd == RSHIM_IOC_WRITE2) {
       pthread_mutex_lock(&bd->mutex);
@@ -1186,7 +1185,7 @@ static int rshim_fuse_rshim_ioctl(struct cuse_dev *cdev, int fflags,
     if (rc == CUSE_ERR_NONE) {
       data = msg2.data;
       rc = bd->read_rshim(bd,
-                           (msg2.addr >> 16) & 0xF, /* channel # */
+                           msg2.addr >> 16, /* channel # */
                            msg2.addr & 0xFFFF, /* addr */
                            &data, msg2.data_size);
       if (!rc)
@@ -1200,7 +1199,7 @@ static int rshim_fuse_rshim_ioctl(struct cuse_dev *cdev, int fflags,
     rc = cuse_copy_in(peer_data, &msg2, sizeof(msg2));
 
     rc = bd->write_rshim(bd,
-                         (msg2.addr >> 16) & 0xF, /* channel # */
+                         msg2.addr >> 16, /* channel # */
                          msg2.addr & 0xFFFF, /* addr */
                          msg2.data, msg2.data_size);
     if (rc)

--- a/src/rshim_pcie_lf.c
+++ b/src/rshim_pcie_lf.c
@@ -646,7 +646,8 @@ static int rshim_boot_fifo_write(struct pci_dev *pci_dev, int addr,
 
 /* RShim read/write routines */
 static int __attribute__ ((noinline))
-rshim_pcie_read(struct rshim_backend *bd, int chan, int addr, uint64_t *result, int size)
+rshim_pcie_read(struct rshim_backend *bd, uint32_t chan, uint32_t addr,
+                uint64_t *result, int size)
 {
   rshim_pcie_lf_t *dev = container_of(bd, rshim_pcie_lf_t, bd);
   struct pci_dev *pci_dev = dev->pci_dev;
@@ -673,7 +674,8 @@ rshim_pcie_read(struct rshim_backend *bd, int chan, int addr, uint64_t *result, 
 }
 
 static int __attribute__ ((noinline))
-rshim_pcie_write(struct rshim_backend *bd, int chan, int addr, uint64_t value, int size)
+rshim_pcie_write(struct rshim_backend *bd, uint32_t chan, uint32_t addr,
+                 uint64_t value, int size)
 {
   rshim_pcie_lf_t *dev = container_of(bd, rshim_pcie_lf_t, bd);
   struct pci_dev *pci_dev = dev->pci_dev;

--- a/src/rshim_regs.h
+++ b/src/rshim_regs.h
@@ -166,6 +166,7 @@
 #define RSH_FABRIC_DIM 0x0110
 
 // Mustang-specific registers' addresses, masks, shifts
+#define BF3_RSH_BASE_ADDR 0x13000000
 #define BF3_RSH_BOOT_FIFO_DATA 0x2000
 #define BF3_RSH_BOOT_FIFO_COUNT 0x1000
 #define BF3_RSH_BOOT_FIFO_COUNT__BOOT_FIFO_COUNT_MASK  0x3ff

--- a/src/rshim_usb.c
+++ b/src/rshim_usb.c
@@ -84,7 +84,7 @@ struct rshim_usb_addr {
 	uint16_t windex;
 };
 
-struct rshim_usb_addr bf3_wvalue_widx_pair_map[] = {
+struct rshim_usb_addr bf3_wval_widx_pair_map[] = {
 	[RSHIM_CHANNEL] = {
 		.wvalue = 0x0300,
 		.windex = 0x0000,
@@ -135,14 +135,15 @@ struct rshim_usb_addr bf3_wvalue_widx_pair_map[] = {
 	},
 };
 
-static struct rshim_usb_addr get_wvalue_windex(int chan, int addr, uint16_t ver_id)
+static struct rshim_usb_addr get_wvalue_windex(int chan, int addr,
+                                               uint16_t ver_id)
 {
   struct rshim_usb_addr rsh_usb_addr;
 
   if (ver_id == RSHIM_BLUEFIELD_3) {
     if (chan <= 0xF) {
-      rsh_usb_addr.wvalue = bf3_wvalue_widx_pair_map[chan].wvalue + BF_MMIO_BASE;
-      rsh_usb_addr.windex = bf3_wvalue_widx_pair_map[chan].windex + addr;
+      rsh_usb_addr.wvalue = bf3_wval_widx_pair_map[chan].wvalue + BF_MMIO_BASE;
+      rsh_usb_addr.windex = bf3_wval_widx_pair_map[chan].windex + addr;
     } else {
       rsh_usb_addr.wvalue = chan;
       rsh_usb_addr.windex = addr;
@@ -157,8 +158,8 @@ static struct rshim_usb_addr get_wvalue_windex(int chan, int addr, uint16_t ver_
 
 /* Rshim read/write routines */
 
-static int rshim_usb_read_rshim(rshim_backend_t *bd, int chan, int addr,
-                                uint64_t *result, int size)
+static int rshim_usb_read_rshim(rshim_backend_t *bd, uint32_t chan,
+                                uint32_t addr, uint64_t *result, int size)
 {
   rshim_usb_t *dev = container_of(bd, rshim_usb_t, bd);
   struct rshim_usb_addr rsh_usb_addr;
@@ -175,6 +176,7 @@ static int rshim_usb_read_rshim(rshim_backend_t *bd, int chan, int addr,
   rsh_usb_addr = get_wvalue_windex(chan, addr, bd->ver_id);
 
   /* Do a blocking control read and endian conversion. */
+  dev->ctrl_data = 0;
   rc = libusb_control_transfer(dev->handle,
                                LIBUSB_ENDPOINT_IN |
                                LIBUSB_REQUEST_TYPE_VENDOR |
@@ -200,8 +202,8 @@ static int rshim_usb_read_rshim(rshim_backend_t *bd, int chan, int addr,
   return rc >= 0 ? (rc > size ? -EINVAL : -ENXIO) : rc;
 }
 
-static int rshim_usb_write_rshim(rshim_backend_t *bd, int chan, int addr,
-                                 uint64_t value, int size)
+static int rshim_usb_write_rshim(rshim_backend_t *bd, uint32_t chan,
+                                 uint32_t addr, uint64_t value, int size)
 {
   rshim_usb_t *dev = container_of(bd, rshim_usb_t, bd);
   struct rshim_usb_addr rsh_usb_addr;


### PR DESCRIPTION
This commit adds 4B access and OPN display for BF3.

Signed-off-by: Liming Sun <limings@nvidia.com>