### PR TITLE
Avoid opening /dev/uio multiple times

### DIFF
--- a/etc/rshim.conf
+++ b/etc/rshim.conf
@@ -3,15 +3,49 @@
 #
 
 #
-# Default configuration for a rshim device
+# Display level for the 'misc' file
 #
 #DISPLAY_LEVEL 0
+
+#
+# Timeout in seconds when pushing BFB while target side is not reading the
+# boot stream
+#
 #BOOT_TIMEOUT  150
+
+#
+# Once set to 1, the driver will ignore all rshim writes and returns 0 for
+# rshim read. It could be used in certain cases, such as during FW_RESET or
+# bypassing the rshim PF to VM
+#
 #DROP_MODE     0
+
+#
+# Delay in seconds for rshim over USB, which is added after chip reset and
+# before pushing the boot stream
+#
 #USB_RESET_DELAY  1
+
+#
+# Delay in seconds for rshim over PCIe, which is added after chip reset and
+# before pushing the boot stream
+#
 #PCIE_RESET_DELAY 5
+
+#
+# Interrupt polling interval in seconds when running rshim over direct memory
+# mapping
+#
 #PCIE_INTR_POLL_INTERVAL 10
+
+#
+# Setting is to 0 will disallow rshim PCIe BAR mapping via VFIO
+#
 #PCIE_HAS_VFIO 1
+
+#
+# Setting is to 0 will disallow rshim PCIe BAR mapping via UIO
+#
 #PCIE_HAS_UIO  1
 
 #


### PR DESCRIPTION
External tools or regression script might toogle the value of DROP_MODE in the rshim misc file, which will trigger function call rshim_pcie_mmap_uio() when UIO is used, thus reopening the /dev/uio file and causing a file handler leak. This commit adds a check to avoid such case. It does't close the handler because the interrupt thread might be still using it.

This commit also adds some comments in the configuration example rshim.conf.