### PR TITLE
Update version to 2.0.7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Copyright (C) 2019 Mellanox Technologies. All Rights Reserved.
 #
 
-AC_INIT([rshim], [2.0.6])
+AC_INIT([rshim], [2.0.7])
 AC_CONFIG_AUX_DIR(config)
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AC_LANG(C)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+rshim (2.0.7) UNRELEASED; urgency=low
+
+  * Avoid opening /dev/uio multiple times
+  * Update common files to dual-license
+  * Adjust rshim reset delay
+
+ -- Liming Sun <limings@nvidia.com>  Thu, 30 Mar 2023 11:40:15 -0400
+
 rshim (2.0.6-19) UNRELEASED; urgency=low
 
   * BF3: Support 4B access for PCIe

--- a/rhel/rshim.spec.in
+++ b/rhel/rshim.spec.in
@@ -4,7 +4,7 @@
 
 Name: rshim
 Version: @VERSION@
-Release: 19%{?dist}
+Release: 0%{?dist}
 Summary: User-space driver for Mellanox BlueField SoC
 
 License: GPLv2
@@ -54,6 +54,11 @@ via the virtual console or network interface.
 %{_mandir}/man8/rshim.8.gz
 
 %changelog
+* Thu Mar 30 2023 Liming Sun <limings@nvidia.com> - 2.0.7
+- Avoid opening /dev/uio multiple times
+- Update common files to dual-license
+- Adjust rshim reset delay
+
 * Sun Nov 20 2022 Liming Sun <limings@nvidia.com> - 2.0.6-19
 - BF3: Support 4B access for PCIe
 

--- a/rshim.spec.in
+++ b/rshim.spec.in
@@ -4,7 +4,7 @@
 
 Name: rshim
 Version: @VERSION@
-Release: 19%{?dist}
+Release: 0%{?dist}
 Summary: User-space driver for Mellanox BlueField SoC
 
 License: GPLv2
@@ -95,6 +95,11 @@ fi
 %{_mandir}/man8/bfb-install.8.gz
 
 %changelog
+* Thu Mar 30 2023 Liming Sun <limings@nvidia.com> - 2.0.7
+- Avoid opening /dev/uio multiple times
+- Update common files to dual-license
+- Adjust rshim reset delay
+
 * Sun Nov 20 2022 Liming Sun <limings@nvidia.com> - 2.0.6-19
 - BF3: Support 4B access for PCIe
 

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -23,8 +23,6 @@
 
 #include "rshim.h"
 
-#define REVISION "19"
-
 /* Maximum number of devices supported (currently it's limited to 64). */
 #define RSHIM_MAX_DEV 64
 
@@ -2937,7 +2935,7 @@ int main(int argc, char *argv[])
       break;
     case 'v':
 #if defined(PACKAGE_NAME) && defined(VERSION)
-      printf(PACKAGE_NAME " " VERSION "-" REVISION "\n");
+      printf(PACKAGE_NAME " " VERSION "\n");
 #else
       printf("Rshim Driver for BlueField SoC 2.0\n");
 #endif


### PR DESCRIPTION
Starting from this build, the dash is removed from tags accoring to https://github.com/Mellanox/rshim-user-space/issues/105.

Fixes #105