### PR TITLE
rshim_pcie: Fix the fall-back logic of direct-mapping

### DIFF
--- a/src/rshim_pcie.c
+++ b/src/rshim_pcie.c
@@ -1092,7 +1092,7 @@ static int rshim_pcie_enable(rshim_backend_t *bd, bool enable)
     }
 
     /* Fall-back to direct map if failed. */
-    if (rc < 0 && dev->mmap_mode == RSHIM_PCIE_MMAP_UIO) {
+    if (rc < 0 && dev->mmap_mode != RSHIM_PCIE_MMAP_DIRECT) {
       RSHIM_INFO("Fall-back to direct io\n");
       rshim_pcie_bind(dev, false);
       dev->pci_path = NULL;


### PR DESCRIPTION
rshim pcie could use VFIO and UIO for memory map, and fall-back to direct-mapping when both fail. This commit adjusts the fall-back condition, so it doesn't have to go through UIO since UIO might be not available on some setups.

RM #3468188