### PR TITLE
Add fuse3 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -85,8 +85,12 @@ AS_IF([test "x$build_fuse" = "xyes"], [
   if test $backend = freebsd; then
     AC_CHECK_LIB(cuse, cuse_dev_create)
   else
-    PKG_CHECK_MODULES(fuse, fuse, [], [AC_MSG_ERROR([Can't find fuse])])
+    PKG_CHECK_MODULES(fuse, fuse, [], PKG_CHECK_MODULES(fuse, fuse3, [use_fuse3=yes], [AC_MSG_ERROR([Can't find fuse])]))
+  if test $use_fuse3 = yes; then
     AC_SUBST(CPPFLAGS, "$CPPFLAGS -DFUSE_USE_VERSION=30")
+  else
+    AC_SUBST(CPPFLAGS, "$CPPFLAGS -DFUSE_USE_VERSION=29")
+  fi
 fi
 ])
 

--- a/rshim.spec.in
+++ b/rshim.spec.in
@@ -13,13 +13,14 @@ URL: https://github.com/mellanox/rshim-user-space
 Source0: https://github.com/mellanox/rshim-user-space/archive/%{name}-%{version}.tar.gz
 
 BuildRequires: gcc, autoconf, automake, pkgconfig, make
-BuildRequires: pkgconfig(libpci), pkgconfig(libusb-1.0), pkgconfig(fuse)
+BuildRequires: pkgconfig(libpci), pkgconfig(libusb-1.0), fuse > 2
 
 %if (0%{?rhel} >= 8 || 0%{?fedora} > 0) && "0%{?ctyunos}" == "0"
 Requires: kernel-modules-extra
 %endif
 
 %global with_systemd %(if (test -d "%{_unitdir}" > /dev/null); then echo -n '1'; else echo -n '0'; fi)
+%global debug_package %{nil}
 
 %description
 This is the user-space driver to access the BlueField SoC via the rshim

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -19,8 +19,13 @@
 #include <sys/timerfd.h>
 
 #ifdef __linux__
+#if FUSE_USE_VERSION >= 30
+#include <fuse3/cuse_lowlevel.h>
+#include <fuse3/fuse_opt.h>
+#else
 #include <fuse/cuse_lowlevel.h>
 #include <fuse/fuse_opt.h>
+#endif
 #include <unistd.h>
 #elif defined(__FreeBSD__)
 #include <termios.h>
@@ -1299,6 +1304,7 @@ int rshim_fuse_init(rshim_backend_t *bd)
   for (i = 0; i < RSH_DEV_TYPES; i++) {
 #ifdef __linux__
     static const char * const argv[] = {"./rshim", "-f"};
+    int multithreaded = 0;
 
     name = rshim_dev_minor_names[i];
 
@@ -1320,7 +1326,7 @@ int rshim_fuse_init(rshim_backend_t *bd)
       continue;
     bd->fuse_session[i] = cuse_lowlevel_setup(sizeof(argv)/sizeof(char *),
                                       (char **)argv,
-                                      &ci, ops[i], NULL, bd);
+                                      &ci, ops[i], &multithreaded, bd);
     if (!bd->fuse_session[i]) {
       RSHIM_ERR("Failed to setup CUSE %s\n", name);
       return -1;


### PR DESCRIPTION
Some Linux distributions only have fuse3 available. This commit adds support to detect and use fuse3.

Signed-off-by: Liming Sun <limings@nvidia.com>

RM #3623445