### PR TITLE
Remove the libfuse build dependency

### DIFF
--- a/rshim.spec.in
+++ b/rshim.spec.in
@@ -13,7 +13,7 @@ URL: https://github.com/mellanox/rshim-user-space
 Source0: https://github.com/mellanox/rshim-user-space/archive/%{name}-%{version}.tar.gz
 
 BuildRequires: gcc, autoconf, automake, pkgconfig, make
-BuildRequires: pkgconfig(libpci), pkgconfig(libusb-1.0), fuse > 2
+BuildRequires: pkgconfig(libpci), pkgconfig(libusb-1.0)
 
 %if (0%{?rhel} >= 8 || 0%{?fedora} > 0) && "0%{?ctyunos}" == "0"
 Requires: kernel-modules-extra


### PR DESCRIPTION
This commit temporarily remove the build dependency on libfuse to unblock some build regression which is not able to handle such syntax. It'll be added back later once the build environment is fixed.