### PR TITLE
Clear scratchpad1 register when setting drop_mode

### DIFF
--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -843,16 +843,17 @@ static int rshim_fuse_misc_write(struct cuse_dev *cdev, int fflags,
 
     pthread_mutex_lock(&bd->mutex);
     old_value = (int)bd->drop_mode;
-    bd->drop_mode = !!value;
-    if (bd->drop_mode == old_value) {
+    value = !!value;
+    if (value == old_value) {
       pthread_mutex_unlock(&bd->mutex);
       goto done;
     }
 
-    if (bd->enable_device) {
-      if (bd->enable_device(bd, bd->drop_mode ? false : true))
-        bd->drop_mode = 1;
-    }
+    bd->drop_mode = 0;
+    if (bd->enable_device && bd->enable_device(bd, value ? false : true))
+      bd->drop_mode = 1;
+    else
+      bd->drop_mode = value;
 
     if (bd->drop_mode)
       bd->drop_pkt = 1;


### PR DESCRIPTION
scratchpad1 register is used for keepalive mechanism, and also used by NIC_FW to tell whether rshim driver is running or not. This register should be cleared to 0 when 'drop-mode' is set. This commit fixes the ordering of the logic when setting 'bd->drop_mode', so it's set yet when calling bd->enable_device() which will update the scratchpad1 register.

RM #3699400