### PR TITLE
Output SECURE_NIC_MODE status in /dev/rshimN/misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,13 @@ syntax: rshim [--help|-h] [--backend|-b usb|pcie|pcie_lf]
       DISPLAY_LEVEL   0 (0:basic, 1:advanced, 2:log)
       BOOT_MODE       1 (0:rshim, 1:emmc, 2:emmc-boot-swap)
       BOOT_TIMEOUT    100 (seconds)
+      DROP_MODE       0 (0:normal, 1:drop)
       SW_RESET        0 (1: reset)
       DEV_NAME        usb-3.3
+      DEV_INFO        BlueField-3(Rev 1)
+      OPN_STR         9009D3B400ENEA
+      UP_TIME         179752(s)
+      SECURE_NIC_MODE 1 (0:no, 1:yes)
 
   Display more infomation:
 
@@ -80,6 +85,10 @@ syntax: rshim [--help|-h] [--backend|-b usb|pcie|pcie_lf]
   Initiate a SW reset:
     
     echo "SW_RESET 1" > /dev/rshim<N>/misc
+
+  When 'SECURE_NIC_MODE' is shown as 1, the NIC firmware is in Secure NIC mode
+  and most rshim functionalities are disabled. This mode applies to PCIe rshim
+  backend only. PCIe LF and USB rshim backends are not affected.
 
 *) Multiple Boards Support
 

--- a/src/rshim_regs.h
+++ b/src/rshim_regs.h
@@ -190,6 +190,7 @@
 #define BF3_RSH_ARM_WDG_CONTROL_WCS 0x0000
 #define BF3_RSH_SCRATCH_BUF_DAT 0x0610
 #define BF3_RSH_SCRATCH_BUF_CTL 0x0600
+#define BF3_RSH_SECURE_NIC_MODE_MAGIC_NUM 0x4B434F4C00000000ULL     /* "LOCK" */
 
 #endif /* !defined(__DOXYGEN__) */
 #endif /* !defined(__RSHIM_REGS_H__) */


### PR DESCRIPTION
This is for the feature of [[Feature #3751187]: [Design] - [BF3][NIC Mode] Secure NIC mode](https://redmine.mellanox.com/issues/3751187). Outputting a mode indication to "/dev/rshimN/misc:" device node for the PCIe host when the NIC FW is in locked mode.