### PR TITLE
Add some robust fixes for the DROP_MODE

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -952,10 +952,13 @@ static int rshim_fifo_tx_avail(rshim_backend_t *bd)
   return avail;
 }
 
-static int rshim_fifo_sync(rshim_backend_t *bd)
+int rshim_fifo_sync(rshim_backend_t *bd)
 {
   rshim_tmfifo_msg_hdr_t hdr;
   int i, avail, rc;
+
+  bd->net_rx_len = 0;
+  bd->net_tx_len = 0;
 
   avail = rshim_fifo_tx_avail(bd);
   if (avail < 0)

--- a/src/rshim.h
+++ b/src/rshim.h
@@ -609,4 +609,7 @@ int rshim_set_opn(rshim_backend_t *bd, const char *opn, int len);
 /* Check whether rshim backend is accessible or not. */
 int rshim_access_check(rshim_backend_t *bd);
 
+/* Sync up with the peer side. */
+int rshim_fifo_sync(rshim_backend_t *bd);
+
 #endif /* _RSHIM_H */

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -873,6 +873,8 @@ static int rshim_fuse_misc_write(struct cuse_dev *cdev, int fflags,
 
     if (bd->drop_mode)
       bd->drop_pkt = 1;
+    else
+      rshim_fifo_sync(bd);
     pthread_mutex_unlock(&bd->mutex);
     /*
      * Check if another endpoint driver has already attached to the


### PR DESCRIPTION
This commit has two robust changes for DROP_MODE which is set to disable access to rshim.

 - Call rshim_fifo_sync() to send zero-padding to peer side in case the DROP_MODE was enabled when the peer side is in the middle of receiving a packet.

 - Clear the net_rx_len & net_tx_len to abort the current Rx & Tx when DROP_MODE is cleared.

RM #3823043