### PR TITLE
DROP_MODE: sync-up the Rx FIFO when clearing DROP_MODE

### DIFF
--- a/src/rshim.h
+++ b/src/rshim.h
@@ -610,6 +610,6 @@ int rshim_set_opn(rshim_backend_t *bd, const char *opn, int len);
 int rshim_access_check(rshim_backend_t *bd);
 
 /* Sync up with the peer side. */
-int rshim_fifo_sync(rshim_backend_t *bd);
+int rshim_fifo_sync(rshim_backend_t *bd, bool drop_rx);
 
 #endif /* _RSHIM_H */

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -874,7 +874,7 @@ static int rshim_fuse_misc_write(struct cuse_dev *cdev, int fflags,
     if (bd->drop_mode)
       bd->drop_pkt = 1;
     else
-      rshim_fifo_sync(bd);
+      rshim_fifo_sync(bd, true);
     pthread_mutex_unlock(&bd->mutex);
     /*
      * Check if another endpoint driver has already attached to the


### PR DESCRIPTION
Since DROP_MODE is a special mode to block rshim access, there could be leftover data in the Rx FIFO which causes packet out-of-sync when rshim access is re-enabled. This commit avoid such issue by draining the Rx FIFO when DROP_MODE is cleared.