### PR TITLE
Avoid a race of rshim ownership during bfb push

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -786,15 +786,14 @@ int rshim_boot_open(rshim_backend_t *bd)
 boot_open_done:
   rshim_ref(bd);
 
-  /*
-   * PCIe doesn't have the disconnect/reconnect behavior.
-   * Add a small delay for the reset.
-   */
+  /* Add a small delay for the reset. */
+  if (!bd->has_reprobe)
+    usleep(500000);
+  pthread_mutex_unlock(&bd->mutex);
+
   if (!bd->has_reprobe)
     sleep(bd->reset_delay);
-
   time(&bd->boot_write_time);
-  pthread_mutex_unlock(&bd->mutex);
 
   return 0;
 }


### PR DESCRIPTION
When pushing BFB from PCIe host, the driver will reset the chip then start to push boot stream after a delay. The delay was added with the mutex taken, which blocks other access including the periodic timer which updates scratchpad1 for ownership, while at the same time the rshim driver on DPU BMC could be activated and take the ownership during this delay. This commit adds 0.5s initial delay for the ARM reset, then release the mutex so the timer function could kick in to update the scratchpad1 register. The original boot stream delay is moved after releasing the mutex.

RM #3835006