### PR TITLE
bfb-install: Remove the monitor of 'In Enhanced NIC mode'

### DIFF
--- a/scripts/bfb-install
+++ b/scripts/bfb-install
@@ -364,7 +364,7 @@ wait_for_update_to_finish()
     sleep 1
 
     if echo ${cur} | grep -Ei \
-      "Reboot|finished|DPU is ready|In Enhanced NIC mode|Linux up" \
+      "Reboot|finished|DPU is ready|Linux up" \
         >/dev/null; then
       finished=1
     fi


### PR DESCRIPTION
This commit removes the monitor of 'In Enhanced NIC mode' message due to behavior change that this message is not the last one anymore when installing BFB in enhanced NIC mode.