### PR TITLE
Lower log level for register read errors as it's normal during reset

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -2146,7 +2146,7 @@ static int rshim_check_locked_mode(rshim_backend_t *bd)
     rc = bd->read_rshim(bd, RSHIM_CHANNEL, bd->regs->scratchpad1, &value,
                         RSHIM_REG_SIZE_8B);
     if (rc < 0) {
-        RSHIM_ERR("RSHIM %d SCRATCHPAD1 register read error\n", bd->index);
+        RSHIM_DBG("RSHIM %d SCRATCHPAD1 register read error\n", bd->index);
         return -EIO;
     }
 


### PR DESCRIPTION
This is to address https://redmine.mellanox.com/issues/3881613 (FR #3881613 - RSHIM 0 SCRATCHPAD1 register read error seen in rshim log on bfb push)