### PR TITLE
Prevent rshim from being enabled and starting after installation

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    configure)
+        echo "Installation complete. To enable and start the rshim service, run:"
+        echo "  systemctl daemon-reload"
+        echo "  systemctl enable rshim"
+        echo "  systemctl start rshim"
+        ;;
+esac

--- a/debian/rules
+++ b/debian/rules
@@ -8,5 +8,3 @@ override_dh_auto_configure:
 
 override_dh_auto_install:
 	dh_auto_install
-	dh_systemd_enable || true
-	dh_systemd_start || true

--- a/rshim.spec.in
+++ b/rshim.spec.in
@@ -65,9 +65,10 @@ make
 
 %post
 %if "%{with_systemd}" == "1"
-  systemctl daemon-reload
-  systemctl enable rshim
-  systemctl start rshim
+  echo "Installation complete. To enable and start the rshim service, run:"
+  echo "  systemctl daemon-reload"
+  echo "  systemctl enable rshim"
+  echo "  systemctl start rshim"
 %endif
 
 %preun


### PR DESCRIPTION
For RM #3754786: [BF][RSHIM] installation of RSHIM on host should be disabled by default (OFED + DOCA-for-host + WinOF-2)
https://redmine.mellanox.com/issues/3754786

Tested on
* RPM: CentOS@amd64
* RPM: CentOS@arm64
* DEB: Ubuntu@amd64
* DEB: Ubuntu@arm64 (installation not tested)

