### PR TITLE
some robust fixes

### DIFF
--- a/src/rshim.h
+++ b/src/rshim.h
@@ -100,6 +100,10 @@ extern int rshim_pcie_enable_uio;
 
 #define BF3_MAX_BOOT_FIFO_SIZE 8192 /* bytes */
 
+/*
+ * Possible error code during resetting, which can be used to check against
+ * registers with known values.
+ */
 #define RSHIM_BAD_CTRL_REG(v) \
   (((v) == 0xbad00acce55) || ((v) == (uint64_t)-1) || ((v) == 0xbadacce55))
 

--- a/src/rshim_pcie.c
+++ b/src/rshim_pcie.c
@@ -1236,7 +1236,7 @@ static int rshim_pcie_probe(struct pci_dev *pci_dev)
   if (rshim_has_pcie_reset_delay || bd->ver_id < RSHIM_BLUEFIELD_3)
     bd->reset_delay = rshim_pcie_reset_delay;
   else
-    bd->reset_delay = 1; /* minimum delay for BF3 */
+    bd->reset_delay = 3; /* minimum delay for BF3 */
 
   /* Initialize object */
   dev->device_id = pci_dev->device_id;


### PR DESCRIPTION
This pull has two robust fixes:
1. Add a check to avoid polling the 'blocked' state during reset;
2. Adjust the default PCIe reset delay to avoid boot stream corruption.