### PR TITLE
pcie-lf driver enhancement to support register read/write with the bf_reg.py script

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -764,9 +764,9 @@ int rshim_boot_open(rshim_backend_t *bd)
 boot_open_done:
   rshim_ref(bd);
 
-  /* Add a small delay for the reset. */
+  /* Add a small delay for the reset (livefish needs more delay). */
   if (!bd->has_reprobe)
-    usleep(500000);
+    usleep((bd->type == RSH_BACKEND_PCIE_LF) ? 1000000 : 500000);
   pthread_mutex_unlock(&bd->mutex);
 
   if (!bd->has_reprobe)
@@ -2612,10 +2612,10 @@ static void rshim_main(int argc, char *argv[])
   if (!rshim_backend_name && rshim_static_dev_name) {
     if (!strncmp(rshim_static_dev_name, "usb", 3))
       rshim_backend_name = "usb";
+    else if (!strncmp(rshim_static_dev_name, "pcie-lf", 7))
+      rshim_backend_name = "pcie-lf";
     else if (!strncmp(rshim_static_dev_name, "pcie", 4))
       rshim_backend_name = "pcie";
-    else if (!strncmp(rshim_static_dev_name, "pcie_lf", 7))
-      rshim_backend_name = "pcie_lf";
   }
   if (!rshim_backend_name) {
     rshim_pcie_init();
@@ -2623,10 +2623,10 @@ static void rshim_main(int argc, char *argv[])
   } else {
     if (!strcmp(rshim_backend_name, "usb"))
       rc = rshim_usb_init(epoll_fd);
+    else if (!strcmp(rshim_backend_name, "pcie-lf"))
+      rc = rshim_pcie_lf_init();
     else if (!strcmp(rshim_backend_name, "pcie"))
       rc = rshim_pcie_init();
-    else if (!strcmp(rshim_backend_name, "pcie_lf"))
-      rc = rshim_pcie_lf_init();
   }
   if (rc) {
     RSHIM_ERR("failed to initialize rshim backend\n");
@@ -2934,7 +2934,7 @@ static void print_help(void)
   printf("Usage: rshim [options]\n");
   printf("\n");
   printf("OPTIONS:\n");
-  printf("  -b, --backend     backend name (usb, pcie or pcie_lf)\n");
+  printf("  -b, --backend     backend name (usb, pcie or pcie-lf)\n");
   printf("  -d, --device      device to attach\n");
   printf("  -f, --foreground  run in foreground\n");
   printf("  -i, --index       use device path /dev/rshim<i>/\n");

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -2130,6 +2130,10 @@ static int rshim_update_locked_mode(rshim_backend_t *bd)
 {
   int locked_mode;
 
+  /* Only do this for PCIE. */
+  if (bd->type != RSH_BACKEND_PCIE)
+    return 0;
+
   /* Skip locked-mode polling during reset. */
   if (bd->is_booting)
     return 0;
@@ -2186,7 +2190,7 @@ static void rshim_timer_func(rshim_backend_t *bd) {
   }
 
   /* Some checking for PCIe backend. */
-  if (!strncmp(bd->dev_name, "pcie", 4) && strncmp(bd->dev_name + 4, "-lf", 3))
+  if (bd->type == RSH_BACKEND_PCIE)
     rshim_pcie_check(bd);
 
   bd->timer = rshim_timer_ticks + period;

--- a/src/rshim.h
+++ b/src/rshim.h
@@ -107,6 +107,14 @@ extern int rshim_pcie_enable_uio;
 #define RSHIM_BAD_CTRL_REG(v) \
   (((v) == 0xbad00acce55) || ((v) == (uint64_t)-1) || ((v) == 0xbadacce55))
 
+/* Backend type. */
+typedef enum {
+  RSH_BACKEND_NONE,
+  RSH_BACKEND_USB,
+  RSH_BACKEND_PCIE,
+  RSH_BACKEND_PCIE_LF
+} rshim_backend_type_t;
+
 /* Sub-device types. */
 enum {
   RSH_DEV_TYPE_RSHIM,
@@ -285,6 +293,8 @@ struct rshim_backend {
   uint32_t skip_boot_reset : 1;   /* Skip SW_RESET while pushing boot stream. */
   uint32_t locked_mode : 1;       /* Secure NIC mode Management. No RSHIM HW access */
 
+  /* type. */
+  rshim_backend_type_t type;
 
   /* reference count. */
   volatile int ref;

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -1067,9 +1067,8 @@ static void rshim_fuse_rshim_ioctl(fuse_req_t req, int cmd, void *arg,
      */
     chan = msg.addr >> 16;
     offset = msg.addr & 0xFFFF;
-    if (bd->ver_id <= RSHIM_BLUEFIELD_2 || strncmp(bd->dev_name, "usb", 3)) {
+    if ((bd->ver_id <= RSHIM_BLUEFIELD_2) || (bd->type != RSH_BACKEND_USB))
       chan &= 0xF;
-    }
 
     if (cmd == RSHIM_IOC_WRITE) {
       pthread_mutex_lock(&bd->mutex);

--- a/src/rshim_pcie.c
+++ b/src/rshim_pcie.c
@@ -1192,6 +1192,7 @@ static int rshim_pcie_probe(struct pci_dev *pci_dev)
 
     bd = &dev->bd;
     strcpy(bd->dev_name, dev_name);
+    bd->type = RSH_BACKEND_PCIE;
     bd->drop_mode = (rshim_drop_mode >= 0) ? rshim_drop_mode : 0;
     bd->locked_mode = 0;
     bd->read_rshim = rshim_pcie_read;

--- a/src/rshim_pcie_lf.c
+++ b/src/rshim_pcie_lf.c
@@ -759,6 +759,7 @@ static int rshim_pcie_probe(struct pci_dev *pci_dev)
     bd = &dev->bd;
     strcpy(bd->dev_name, dev_name);
     /* Enable drop mode by default if not configured. */
+    bd->type = RSH_BACKEND_PCIE_LF;
     bd->drop_mode = (rshim_drop_mode >= 0) ? rshim_drop_mode : 1;
     bd->read_rshim = rshim_pcie_read;
     bd->write_rshim = rshim_pcie_write;

--- a/src/rshim_regs.h
+++ b/src/rshim_regs.h
@@ -166,6 +166,7 @@
 #define RSH_FABRIC_DIM 0x0110
 
 // Mustang-specific registers' addresses, masks, shifts
+#define BF3_RSH_ADDR_MASK 0x10000000
 #define BF3_RSH_BASE_ADDR 0x13000000
 #define BF3_RSH_BOOT_FIFO_DATA 0x2000
 #define BF3_RSH_BOOT_FIFO_COUNT 0x1000

--- a/src/rshim_usb.c
+++ b/src/rshim_usb.c
@@ -779,6 +779,7 @@ static int rshim_usb_probe_one(libusb_context *ctx, libusb_device *usb_dev,
 
     bd = &dev->bd;
     strcpy(bd->dev_name, dev_name);
+    bd->type = RSH_BACKEND_USB;
     bd->drop_mode = (rshim_drop_mode >= 0) ? rshim_drop_mode : 0;
     bd->read = rshim_usb_backend_read;
     bd->write = rshim_usb_backend_write;


### PR DESCRIPTION
This one is needed by RM #3892195 to support register read/write by pcie-lf driver. 

During the testing for livefish driver, two more fixes are also made:
1. Cleanup the code to remove the workaround for BF2 A0;
2. Add a check to do 'blocked' state checking only for PCIe backend.