### PR TITLE
bfb-install: add runtime image support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ SUBDIRS = src man
 dist_doc_DATA = README.md
 confdir = $(sysconfdir)
 dist_conf_DATA = etc/rshim.conf
-dist_sbin_SCRIPTS = scripts/bfb-install
+dist_sbin_SCRIPTS = scripts/bfb-install scripts/bf-reg
 
 AM_DISTCHECK_CONFIGURE_FLAGS = \
   --with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir)

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -2,4 +2,4 @@
 # Copyright (C) 2019 Mellanox Technologies. All Rights Reserved.
 #
 
-man8_MANS = rshim.8 bfb-install.8
+man8_MANS = rshim.8 bfb-install.8 bf-reg.8

--- a/man/bf-reg.8
+++ b/man/bf-reg.8
@@ -1,0 +1,17 @@
+.\" Manpage for bf-reg.
+.TH man 8 "6 Jun 2024" "1.0" "bf-reg man page"
+.SH NAME
+bf-reg \- Register access of BlueField SoC over the rshim driver
+
+.SH SYNOPSIS
+.B bf-reg
+Usage: ./bf-reg rshim<N> <hex_addr>.<32|64> [value]
+
+.SH DESCRIPTION
+
+bf-reg is a utility script to access registers of BlueField SoC over the
+rshim driver.
+
+.SH KNOWN ISSUES
+
+This script only supports BF3 for now.

--- a/rshim.spec.in
+++ b/rshim.spec.in
@@ -52,9 +52,11 @@ make
 %{__install} -d %{buildroot}%{_mandir}/man8
 %{__install} -m 0644 man/rshim.8 %{buildroot}%{_mandir}/man8
 %{__install} -m 0644 man/bfb-install.8 %{buildroot}%{_mandir}/man8
+%{__install} -m 0644 man/bf-reg.8 %{buildroot}%{_mandir}/man8
 %{__install} -d %{buildroot}%{_sysconfdir}
 %{__install} -m 0644 etc/rshim.conf %{buildroot}%{_sysconfdir}
 %{__install} -m 0755 scripts/bfb-install %{buildroot}%{_sbindir}
+%{__install} -m 0755 scripts/bf-reg %{buildroot}%{_sbindir}
 
 %pre
 %if "%{with_systemd}" == "1"
@@ -93,8 +95,10 @@ fi
 %endif
 %{_sbindir}/rshim
 %{_sbindir}/bfb-install
+%{_sbindir}/bf-reg
 %{_mandir}/man8/rshim.8.gz
 %{_mandir}/man8/bfb-install.8.gz
+%{_mandir}/man8/bf-reg.8.gz
 
 %changelog
 * Tue Jun 04 2024 Liming Sun <limings@nvidia.com> - 2.0.32

--- a/scripts/bf-reg
+++ b/scripts/bf-reg
@@ -1,0 +1,75 @@
+#! /usr/bin/env perl
+#
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+
+use strict;
+use warnings;
+
+my $RSHIM_IOC_READ = 0xc00d5200;
+my $RSHIM_IOC_WRITE = 0xc00d5201;
+
+sub usage {
+    $0 =~ m|[^/]+$|;
+    print "Usage: ./$& rshim<N> <hex_addr>.<32|64> [value]\n";
+    print "\n";
+    exit 1;
+}
+
+sub str2int {
+    if (substr($_[0], 0, 2) eq "0x") {
+        return hex($_[0]);
+    } else {
+        return int($_[0]);
+    }
+}
+
+my $s1 = $ARGV[1] || usage;
+my @s2 = split(/\./, $s1);
+my $addr = str2int($s2[0]) | 0x10000000;
+if (scalar(@s2) != 2) {
+    usage
+}
+my $size = str2int($s2[1]) / 8;
+my $value_lo = 0;
+my $value_hi = 0;
+my $is_read = 1;
+if (scalar(@ARGV) > 2) {
+    if (substr($ARGV[2], 0, 2) eq "0x") {
+        if (length($ARGV[2]) <= 10) {
+            $value_lo = str2int($ARGV[2]);
+        } else {
+            $value_lo = hex(substr($ARGV[2], -8, 8));
+            $value_hi = hex(substr($ARGV[2], 0, length($ARGV[2]) - 8));
+        }
+    } else {
+        $value_lo = str2int($ARGV[2]);
+    }
+    $is_read = 0;
+}
+
+open(FH, '>', "/dev/$ARGV[0]/rshim") or die $!;
+
+my $data = pack('LLLC', $addr, $value_lo, $value_hi, $size);
+if ($is_read) {
+    ioctl FH, $RSHIM_IOC_READ, $data || die "can't ioctl: $!";
+} else {
+    ioctl FH, $RSHIM_IOC_WRITE, $data || die "can't ioctl: $!";
+    if ($size) {
+        printf "[0x%x] <- 0x%08x%08x\n", $addr, $value_hi, $value_lo;
+    } else {
+        printf "[0x%x] <- 0x%08x\n", $addr, $value_lo;
+    }
+}
+
+my @ret;
+if ($is_read) {
+    @ret = unpack('L<L<L<B', $data);
+    if ($size) {
+        printf "[0x%x] -> 0x%08x%08x\n", $addr, $ret[2], $ret[1];
+    } else {
+        printf "[0x%x] -> 0x%08x\n", $addr, $ret[1];
+    }
+}
+
+close(FH);

--- a/scripts/bfb-install
+++ b/scripts/bfb-install
@@ -33,6 +33,7 @@
 
 DEBUG=${DEBUG:-0}                             # Debug mode
 RSHIM_PIPE="/tmp/rshim_pipe"
+BF_REG=$(dirname $0)/bf-reg
 
 usage ()
 {
@@ -45,6 +46,7 @@ usage ()
   echo "  -m, --remote-mode <mode>       Remote mode to use (scp, nc, ncpipe)."
   echo "  -r, --rshim <device>           Rshim device, format [<ip>:<port>:]rshim<N>."
   echo "  -R, --reverse-nc               Reverse netcat mode."
+  echo "  -u, --runtime                  Runtime upgrade (BF3 + local rshim only)."
   echo "  -v, --verbose                  Enable verbose output."
 }
 
@@ -165,6 +167,19 @@ get_local_ip()
   echo $local_ip
 }
 
+clear_boot_fifo()
+{
+  local cnt
+
+  while true; do
+    # Read BOOT_FIFO_DATA if BOOT_FIFO_COUNT != 0
+    cnt=`${BF_REG} $(basename ${rshim_node}) 0x13001000.64 | awk '{print $3}'`
+    cnt=$((cnt))
+    [ $cnt -eq 0 ] && break
+    ${BF_REG} $(basename ${rshim_node}) 0x13002000.64 >/dev/null
+  done
+}
+
 # Push the boot stream to rshim via local rshim
 #
 # Global variables used:
@@ -173,7 +188,21 @@ push_boot_stream_via_local_rshim()
 {
   # Push the boot stream to local rshim
   echo "Pushing bfb${cfg:+ + cfg}${rootfs:+ + rootfs}"
+
+  if [ $runtime -eq 1 ]; then
+    # Skip reset when pushing bfb
+    echo "BOOT_RESET_SKIP 1" > ${rshim_node}/misc
+    # Clear the current boot fifo
+    clear_boot_fifo
+    # Set SP2.BIT2=1
+    ${BF_REG} $(basename ${rshim_node}) 0x13000c48.64 0x4 >/dev/null
+  fi
+
   $sudo_prefix sh -c "cat ${bfb} ${cfg:+$cfg} ${rootfs:+${rootfs}} ${pv:+| ${pv} | cat -} > ${rshim_node}/boot"
+
+  if [ $runtime -eq 1 ]; then
+    echo "BOOT_RESET_SKIP 0" > ${rshim_node}/misc
+  fi
 }
 
 # Push the boot stream to rshim via remote rshim with scp
@@ -348,6 +377,14 @@ push_boot_stream()
 #   $mode, $rshim_node, $remote_mode
 wait_for_update_to_finish()
 {
+  local filter="Reboot|finished|DPU is ready|Linux up"
+
+  if [ $runtime -eq 0 ]; then
+    filter="$filter|In Enhanced NIC mode"
+  else
+    filter="Runtime upgrade finished"
+  fi
+
   echo "Collecting BlueField booting status. Press Ctrl+C to stop…"
 
   # Set display level to 2 to show more information
@@ -363,9 +400,7 @@ wait_for_update_to_finish()
 
     sleep 1
 
-    if echo ${cur} | grep -Ei \
-      "Reboot|finished|DPU is ready|In Enhanced NIC mode|Linux up" \
-        >/dev/null; then
+    if echo ${cur} | grep -Ei "$filter" >/dev/null; then
       finished=1
     fi
 
@@ -438,6 +473,7 @@ rootfs=
 mode=local        # Values can be local or remote
 remote_mode=      # Values can be scp, nc, or ncpipe
 rshim=            # rshim device string, format [<ip>:<port>:]rshim<N>
+runtime=0         # Values can be 0 or 1.
 verbose=0         # Values can be 0 or 1.
 reverse_nc=0      # Values can be 0 or 1.
 
@@ -451,8 +487,8 @@ trap cleanup EXIT INT TERM
 run_cmd_local_ready=0     # whether run_cmd* local functions are ready to use
 run_cmd_remote_ready=0    # whether run_cmd* remote functions are ready to use
 
-options=`getopt -n bfb-install -o b:c:f:hm:r:Rv \
-        -l bfb:,config:,rootfs:,help,remote-mode:,rshim:,reverse-nc,verbose \
+options=`getopt -n bfb-install -o b:c:f:hm:r:Ruv \
+        -l bfb:,config:,rootfs:,help,remote-mode:,rshim:,reverse-nc,runtime,verbose \
         -- "$@"`
 if [ $? != 0 ]; then echo "Command line error" >&2; exit 1; fi
 eval set -- $options
@@ -465,6 +501,7 @@ while [ "$1" != -- ]; do
     --remote-mode|-m) shift; remote_mode=$1 ;;
     --rshim|-r) shift; rshim=$1 ;;
     --reverse-nc|-R) reverse_nc=1 ;;
+    --runtime|-u) runtime=1 ;;
     --verbose|-v) verbose=1 ;;
     --) shift; break;;
     *) echo "Error: Invalid argument: $1" >&2; usage >&2; exit 1 ;;


### PR DESCRIPTION
This commit enables runtime image upgrade with the '-u' option, so image can be pushed without resetting the DPU. It'll expect rshim log 'Runtime upgrade finished' to exit the polling.

A utility script bf_reg.pl is added to access registers via rshim. It's in perl, so it could be used on DPU BMC as well by default.

It also has a new misc command 'CLEAR_ON_READ'. If set, the rshim log will be cleared after read.