### PR TITLE
misc: add 'CLEAR_ON_READ' command

### DIFF
--- a/src/rshim.h
+++ b/src/rshim.h
@@ -292,6 +292,7 @@ struct rshim_backend {
   uint32_t drop_mode : 1;         /* A flag to drop all input/output. */
   uint32_t skip_boot_reset : 1;   /* Skip SW_RESET while pushing boot stream. */
   uint32_t locked_mode : 1;       /* Secure NIC mode Management. No RSHIM HW access */
+  uint32_t clear_on_read : 1;     /* Clear rshim log after read */
 
   /* type. */
   rshim_backend_type_t type;

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -719,7 +719,7 @@ static int rshim_fuse_misc_read(struct cuse_dev *cdev, int fflags,
                  bd->locked_mode);
     p += n;
     len -= n;
-}
+  }
 
   if (bd->display_level == 1) {
     gettimeofday(&tp, NULL);
@@ -757,6 +757,11 @@ static int rshim_fuse_misc_read(struct cuse_dev *cdev, int fflags,
 
     n = snprintf(p, len, "%-16s%d %d (rw)\n",
                    "VLAN_ID", bd->vlan[0], bd->vlan[1]);
+    p += n;
+    len -= n;
+
+    n = snprintf(p, len, "%-16s%d (0:no, 1:yes)\n", "CLEAR_ON_READ",
+                 bd->clear_on_read);
     p += n;
   } else if (bd->display_level == 2) {
     n = rshim_log_show(bd, p, len);
@@ -847,6 +852,10 @@ static int rshim_fuse_misc_write(struct cuse_dev *cdev, int fflags,
     if (sscanf(p, "%d", &value) != 1)
       goto invalid;
     rshim_set_drop_mode(bd, value);
+  } else if (strcmp(key, "CLEAR_ON_READ") == 0) {
+    if (sscanf(p, "%d", &value) != 1)
+      goto invalid;
+    bd->clear_on_read = !!value;
   } else if (strcmp(key, "BOOT_MODE") == 0) {
     if (sscanf(p, "%x", &value) != 1)
       goto invalid;

--- a/src/rshim_log.c
+++ b/src/rshim_log.c
@@ -374,8 +374,9 @@ int rshim_log_show(rshim_backend_t *bd, char *buf, int size)
     }
   }
 
-  /* Restore the idx value. */
-  bd->write_rshim(bd, RSHIM_CHANNEL, bd->regs->scratch_buf_ctl, idx, RSHIM_REG_SIZE_8B);
+  /* Clear or Restore the idx value. */
+  bd->write_rshim(bd, RSHIM_CHANNEL, bd->regs->scratch_buf_ctl,
+                  bd->clear_on_read ? 0 : idx, RSHIM_REG_SIZE_8B);
 
 done:
   /* Release the semaphore. */


### PR DESCRIPTION
This command adds the 'CLEAR_ON_READ' misc command. Once set, the rshim log will be cleared after read.