### PR TITLE
Add ownership transfer feature

### DIFF
--- a/etc/rshim.conf
+++ b/etc/rshim.conf
@@ -21,6 +21,18 @@
 #DROP_MODE     0
 
 #
+# Once set to 1, the driver will try to force the other rshim driver using the
+# rshim to release it.
+#
+# For example, if the current rshim driver is running from host via PCIe, but
+# the rshim device is already in use by the other rshim driver running from BMC
+# via USB, then with this option it will try to force the other rshim driver to
+# release the rshim device. The success of this operation depends on the other
+# rshim driver's implementation and behavior.
+#
+#FORCE_CMD     1
+
+#
 # Delay in seconds for rshim over USB, which is added after chip reset and
 # before pushing the boot stream
 #

--- a/man/rshim.8
+++ b/man/rshim.8
@@ -51,6 +51,15 @@ echo "SW_RESET 1" > /dev/rshim<N>/misc
 .fi
 .in
 
+Send a Force command to request the other rshim driver to release the rshim
+device
+
+.in +4n
+.nf
+echo "FORCE_CMD 1" > /dev/rshim<N>/misc
+.fi
+.in
+
 Enable the advanced options
 
 .in +4n
@@ -95,6 +104,17 @@ Specify the device name to attach with the format below. The backend driver can 
 -f, --foreground
 .in +4n
 Run in forground.
+.in
+
+-F, --force
+.in +4n
+Trying to force the other rshim driver to release the rshim device.
+
+For example, if the current rshim driver is running from host via PCIe, but the
+rshim device is already in use by the other rshim driver running from BMC via
+USB, then the user can use this option to try to force the other rshim driver to
+release the rshim device. The success of this operation depends on the other
+rshim driver's implementation and behavior.
 .in
 
 -i, --index

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -1304,11 +1304,10 @@ again:
    */
   if (bd->read_buf_next < bd->read_buf_bytes ||
       (bd->spin_flags & RSH_SFLG_READING)) {
-
     /* We're doing nothing. */
     RSHIM_DBG("fifo_input: no new read: %s\n",
-        (bd->read_buf_next < bd->read_buf_bytes) ?
-        "have data" : "already reading");
+              (bd->read_buf_next < bd->read_buf_bytes) ?
+              "have data" : "already reading");
   } else {
     int len;
 
@@ -1351,8 +1350,7 @@ ssize_t rshim_fifo_read(rshim_backend_t *bd, char *buffer, size_t count,
     int pass1;
     int pass2;
 
-    /* Remove this for now as it's every chatty with -l 4*/
-    /* RSHIM_DBG("fifo_read, top of loop, remaining count %zd\n", count); */
+    RSHIM_DBG("fifo_read, top of loop, remaining count %zd\n", count);
 
     /*
      * We check this each time through the loop since the

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -2277,6 +2277,7 @@ static int rshim_handle_ownership_transfer(rshim_backend_t *bd)
         if (rt) {
           RSHIM_ERR("rshim%d failed to write ownership transfer req\n",
               bd->index);
+          usleep(RSHIM_OSP_TO_REQ_MS * 1000 / 10);
           continue;
         }
 
@@ -2315,8 +2316,13 @@ static int rshim_handle_ownership_transfer(rshim_backend_t *bd)
 
       RSHIM_INFO("Notifying the requester with ACK\n");
       for (i = 0; i < 10; i++) {
-        rshim_write_sp1_magic(bd, RSHIM_OSP_ACK_MAGIC_NUM);
+        rt = rshim_write_sp1_magic(bd, RSHIM_OSP_ACK_MAGIC_NUM);
         usleep(RSHIM_OSP_TO_REQ_MS * 1000 / 10);
+        if (rt) {
+          RSHIM_ERR("rshim%d failed to write ownership transfer ack\n",
+              bd->index);
+          continue;
+        }
       }
 
       usleep(RSHIM_OSP_TO_ONLINE_MS * 1000);

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -2359,21 +2359,21 @@ static int handle_ownership_transfer(rshim_backend_t *bd) {
         return rt;
       }
       RSHIM_INFO("De-registering the rshim device\n");
-      rshim_deregister(bd, false);
+      rshim_deregister(bd, true);
       RSHIM_INFO("Re-registering the rshim device\n");
       bd->has_rshim = 1;
       bd->has_tm = 1;
       rt = rshim_register(bd);
       if (rt || bd->monitor_mode) {
         RSHIM_ERR("Failed to register rshim%d\n", bd->index);
-        rshim_deregister(bd, false);
+        rshim_deregister(bd, true);
         return rt;
       }
       RSHIM_INFO("Sending RSH_EVENT_ATTACH\n");
       rt = rshim_notify(bd, RSH_EVENT_ATTACH, 0);
       if (rt) {
         RSHIM_ERR("Failed to attach rshim%d\n", bd->index);
-        rshim_deregister(bd, false);
+        rshim_deregister(bd, true);
         return rt;
       }
       RSHIM_INFO("rshim%d regained ownership successfully\n", bd->index);
@@ -2392,7 +2392,7 @@ static int handle_ownership_transfer(rshim_backend_t *bd) {
         RSHIM_ERR("Failed to detach rshim%d\n", bd->index);
         return rt;
       }
-      rshim_deregister(bd, false);
+      rshim_deregister(bd, true);
 
       RSHIM_INFO("Notifying the requester with ACK\n");
       for (i = 0; i < 10; i++) {
@@ -2416,13 +2416,13 @@ static int handle_ownership_transfer(rshim_backend_t *bd) {
       rt = rshim_register(bd);
       if (rt) {
         RSHIM_ERR("Failed to register rshim%d\n", bd->index);
-        rshim_deregister(bd, false);
+        rshim_deregister(bd, true);
         return rt;
       }
       rt = rshim_notify(bd, RSH_EVENT_ATTACH, 0);
       if (rt) {
         RSHIM_ERR("Failed to attach rshim%d\n", bd->index);
-        rshim_deregister(bd, false);
+        rshim_deregister(bd, true);
         return rt;
       }
       rshim_unlock();
@@ -2699,7 +2699,7 @@ int rshim_register(rshim_backend_t *bd)
 #ifdef HAVE_RSHIM_FUSE
   rc = rshim_fuse_init(bd);
   if (rc) {
-    rshim_deregister(bd, true);
+    rshim_deregister(bd, false);
     return rc;
   }
 #endif
@@ -2810,7 +2810,7 @@ static void rshim_stop(void)
     pthread_mutex_lock(&bd->mutex);
     if (bd->enable_device)
       bd->enable_device(bd, false);
-    rshim_deregister(bd, true);
+    rshim_deregister(bd, false);
     pthread_mutex_unlock(&bd->mutex);
   }
 

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -2214,7 +2214,8 @@ static int rshim_update_locked_mode(rshim_backend_t *bd)
       has_bd_lock = !pthread_mutex_trylock(&bd->mutex);
       rt = rshim_access_check(bd); 
       if (has_bd_lock)
-        rshim_unlock();
+        pthread_mutex_unlock(&bd->mutex);
+      rshim_unlock();
       if (rt) {
         RSHIM_INFO("rshim%d attached by another device. Entering Drop Mode\n",
             bd->index);

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -2176,7 +2176,7 @@ static int rshim_check_locked_mode(rshim_backend_t *bd)
 static int rshim_update_locked_mode(rshim_backend_t *bd)
 {
   int locked_mode;
-  int has_lock;
+  int has_bd_lock;
 
   /* Only do this for PCIE. */
   if (bd->type != RSH_BACKEND_PCIE)
@@ -2186,11 +2186,11 @@ static int rshim_update_locked_mode(rshim_backend_t *bd)
   if (bd->is_booting)
     return 0;
 
-  has_lock = !pthread_mutex_trylock(&bd->mutex);
+  has_bd_lock = !pthread_mutex_trylock(&bd->mutex);
 
   locked_mode = rshim_check_locked_mode(bd);
   if (locked_mode < 0) {
-    if (has_lock)
+    if (has_bd_lock)
       pthread_mutex_unlock(&bd->mutex);
     return -EIO;
   }
@@ -2216,7 +2216,7 @@ static int rshim_update_locked_mode(rshim_backend_t *bd)
         rt = rshim_set_drop_mode(bd, 1);
         if (rt) {
           RSHIM_ERR("rshim%d failed to enter drop mode\n", bd->index);
-          if (has_lock)
+          if (has_bd_lock)
             pthread_mutex_unlock(&bd->mutex);
           return -EIO;
         }
@@ -2224,7 +2224,7 @@ static int rshim_update_locked_mode(rshim_backend_t *bd)
     }
   }
 
-  if (has_lock)
+  if (has_bd_lock)
     pthread_mutex_unlock(&bd->mutex);
 
   return 0;

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -2126,6 +2126,7 @@ int rshim_set_drop_mode(rshim_backend_t *bd, int value)
     return -EALREADY;
   }
 
+  bd->drop_mode = 0;
   if (bd->enable_device && bd->enable_device(bd, value ? false : true))
     bd->drop_mode = 1;
   else

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -2342,7 +2342,6 @@ static int rshim_handle_ownership_transfer(rshim_backend_t *bd)
       rt = rshim_set_drop_mode(bd, 1);
       if (rt) {
         RSHIM_ERR("rshim%d failed to enter drop mode\n", bd->index);
-        rshim_unlock();
         return rt;
       }
 

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -2264,13 +2264,12 @@ static int rshim_handle_ownership_transfer(rshim_backend_t *bd)
     if (bd->force_cmd_pending) {
       RSHIM_INFO("rshim%d executing Force command\n", bd->index);
       bd->force_cmd_pending = 0;
+      bd->requesting_rshim = 1;
 
       if (bd->enable_device && bd->enable_device(bd, true)) {
         RSHIM_ERR("rshim%d failed to enable device\n", bd->index);
         return -EIO;
       }
-
-      bd->requesting_rshim = 1;
 
       /* sending req and checking ack multiple times to ensure the transfer */
       for (i = 0; i < 10; i++) {

--- a/src/rshim.h
+++ b/src/rshim.h
@@ -297,6 +297,7 @@ struct rshim_backend {
   uint32_t has_locked_work : 1;   /* Need to check locked mode in worker. */
   uint32_t has_osp_work : 1;      /* Need to run ownership (osp) state machine. */
   uint32_t requesting_rshim : 1;  /* Mode that a request is being made to other end */
+  uint32_t in_access_check : 1;   /* Access check is in progress */
 
   /* type. */
   rshim_backend_type_t type;

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -856,7 +856,7 @@ static int rshim_fuse_misc_write(struct cuse_dev *cdev, int fflags,
   } else if (strcmp(key, "DROP_MODE") == 0) {
     if (sscanf(p, "%d", &value) != 1)
       goto invalid;
-    rshim_set_drop_mode(bd, value);
+    rc = rshim_set_drop_mode(bd, value);
   } else if (strcmp(key, "CLEAR_ON_READ") == 0) {
     if (sscanf(p, "%d", &value) != 1)
       goto invalid;

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -680,7 +680,17 @@ static int rshim_fuse_misc_read(struct cuse_dev *cdev, int fflags,
   p += n;
   len -= n;
 
-  /* SW reset flag is always 0. */
+  n = snprintf(p, len, "%-16s%d (0:no access, 1:has access)\n", "RSHIM ACCESS",
+               !bd->access_check_failed);
+  p += n;
+  len -= n;
+
+  n = snprintf(p, len, "%-16s%d (0:no, 1:yes)\n", "MONITOR_MODE",
+               bd->monitor_mode);
+  p += n;
+  len -= n;
+
+    /* SW reset flag is always 0. */
   n = snprintf(p, len, "%-16s%d (1: reset)\n", "SW_RESET", 0);
   p += n;
   len -= n;
@@ -720,6 +730,11 @@ static int rshim_fuse_misc_read(struct cuse_dev *cdev, int fflags,
     p += n;
     len -= n;
   }
+
+  n = snprintf(p, len, "%-16s%d (0:no, 1:yes)\n", "FORCE_CMD",
+      bd->force_cmd_pending);
+  p += n;
+  len -= n;
 
   if (bd->display_level == 1) {
     gettimeofday(&tp, NULL);
@@ -942,6 +957,12 @@ static int rshim_fuse_misc_write(struct cuse_dev *cdev, int fflags,
     if (!rc)
       bd->debug_code = val64;
     pthread_mutex_unlock(&bd->mutex);
+  } else if (strcmp(key, "FORCE_CMD") == 0) {
+    if (sscanf(p, "%x", &value) != 1)
+      goto invalid;
+    if (value && bd->monitor_mode) {
+        bd->force_cmd_pending = 1;
+    }
   } else {
 invalid:
 #ifdef __linux__
@@ -1294,6 +1315,8 @@ int rshim_fuse_init(rshim_backend_t *bd)
 #endif
 
   for (i = 0; i < RSH_DEV_TYPES; i++) {
+    if (bd->access_check_failed && i != RSH_DEV_TYPE_MISC)
+      continue;
 #ifdef __linux__
     static const char * const argv[] = {"./rshim", "-f"};
     int multithreaded = 0;
@@ -1305,6 +1328,10 @@ int rshim_fuse_init(rshim_backend_t *bd)
      * device was re-ceated during SW_RESET.
      */
     snprintf(buf, sizeof(buf), "/dev/rshim%d/%s", bd->index, name);
+    if (i == RSH_DEV_TYPE_MISC && !access(buf, F_OK)) {
+      /* It's OK for misc file to be persistent after fuse_del() */
+      continue;
+    }
     time(&t0);
     while (!access(buf, F_OK)) {
       time(&t1);
@@ -1354,11 +1381,19 @@ int rshim_fuse_init(rshim_backend_t *bd)
   return 0;
 }
 
-int rshim_fuse_del(rshim_backend_t *bd)
+/*
+ * If has_misc is true, we will not delete the "misc" device file even if
+ * other device files like "boot" etc are deregistered. This allows user
+ * to send commands to the driver even if it's not fully attached to rshim
+ * device.
+ */
+int rshim_fuse_del(rshim_backend_t *bd, bool has_misc)
 {
   int i;
 
   for (i = 0; i < RSH_DEV_TYPES; i++) {
+    if (i == RSH_DEV_TYPE_MISC && has_misc)
+      continue;
     if (bd->fuse_session[i]) {
 #ifdef __linux__
       fuse_session_exit(bd->fuse_session[i]);
@@ -1370,6 +1405,8 @@ int rshim_fuse_del(rshim_backend_t *bd)
   }
 
   for (i = 0; i < RSH_DEV_TYPES; i++) {
+    if (i == RSH_DEV_TYPE_MISC && has_misc)
+      continue;
     if (bd->fuse_thread[i]) {
       pthread_kill(bd->fuse_thread[i], SIGINT);
       pthread_join(bd->fuse_thread[i], NULL);

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -680,7 +680,7 @@ static int rshim_fuse_misc_read(struct cuse_dev *cdev, int fflags,
   p += n;
   len -= n;
 
-  n = snprintf(p, len, "%-16s%d (0:no access, 1:has access)\n", "RSHIM ACCESS",
+  n = snprintf(p, len, "%-16s%d (0:no access, 1:has access)\n", "RSHIM_ACCESS",
                !bd->access_check_failed);
   p += n;
   len -= n;

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -856,9 +856,7 @@ static int rshim_fuse_misc_write(struct cuse_dev *cdev, int fflags,
   } else if (strcmp(key, "DROP_MODE") == 0) {
     if (sscanf(p, "%d", &value) != 1)
       goto invalid;
-    pthread_mutex_lock(&bd->mutex);
     rshim_set_drop_mode(bd, value);
-    pthread_mutex_unlock(&bd->mutex);
   } else if (strcmp(key, "CLEAR_ON_READ") == 0) {
     if (sscanf(p, "%d", &value) != 1)
       goto invalid;

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -1315,6 +1315,13 @@ int rshim_fuse_init(rshim_backend_t *bd)
 #endif
 
   for (i = 0; i < RSH_DEV_TYPES; i++) {
+    /* When we don't own the rshim device, we only want to create the "misc"
+     * device file, so the user can monitor the rshim ownership status and
+     * send Force/RequestOwnership to the other end (rshim owner).
+     *
+     * Other functionalities provided by "boot", "console", and "rshim" won't
+     * be available.
+     */
     if (bd->access_check_failed && i != RSH_DEV_TYPE_MISC)
       continue;
 #ifdef __linux__

--- a/src/rshim_pcie.c
+++ b/src/rshim_pcie.c
@@ -1090,7 +1090,7 @@ static void rshim_pcie_delete(rshim_backend_t *bd)
 {
   rshim_pcie_t *dev = container_of(bd, rshim_pcie_t, bd);
 
-  rshim_deregister(bd, true);
+  rshim_deregister(bd, false);
   free(dev);
 }
 

--- a/src/rshim_pcie_lf.c
+++ b/src/rshim_pcie_lf.c
@@ -764,7 +764,7 @@ static void rshim_pcie_delete(struct rshim_backend *bd)
 {
   rshim_pcie_lf_t *dev = container_of(bd, rshim_pcie_lf_t, bd);
 
-  rshim_deregister(bd, true);
+  rshim_deregister(bd, false);
   free(dev);
 }
 

--- a/src/rshim_pcie_lf.c
+++ b/src/rshim_pcie_lf.c
@@ -687,7 +687,7 @@ rshim_pcie_read(struct rshim_backend *bd, uint32_t chan, uint32_t addr,
   struct pci_dev *pci_dev = dev->pci_dev;
   int rc = 0;
 
-  if (!bd->has_rshim || !bd->has_tm)
+  if (!bd->has_rshim)
     return -ENODEV;
 
   if (size != 4 && size != 8)
@@ -720,7 +720,7 @@ rshim_pcie_write(struct rshim_backend *bd, uint32_t chan, uint32_t addr,
   uint64_t result;
   int rc = 0;
 
-  if (!bd->has_rshim || !bd->has_tm)
+  if (!bd->has_rshim)
     return -ENODEV;
 
   if (size != 4 && size != 8)
@@ -764,7 +764,7 @@ static void rshim_pcie_delete(struct rshim_backend *bd)
 {
   rshim_pcie_lf_t *dev = container_of(bd, rshim_pcie_lf_t, bd);
 
-  rshim_deregister(bd);
+  rshim_deregister(bd, true);
   free(dev);
 }
 
@@ -844,16 +844,24 @@ static int rshim_pcie_probe(struct pci_dev *pci_dev)
   bd->has_rshim = 1;
   bd->has_tm = 1;
   ret = rshim_register(bd);
-  if (ret) {
+  if (ret && !bd->access_check_failed) {
     pthread_mutex_unlock(&bd->mutex);
     goto rshim_map_failed;
   }
 
-  /* Notify that the device is attached */
-  ret = rshim_notify(bd, RSH_EVENT_ATTACH, 0);
+  if (!bd->access_check_failed) {
+    /* Notify that the device is attached */
+    ret = rshim_notify(bd, RSH_EVENT_ATTACH, 0);
+  }
+
+  if (rshim_force_mode && bd->monitor_mode) {
+    RSHIM_INFO("rshim%d will send force cmd to the other rshim-active end\n",
+        bd->index);
+    bd->force_cmd_pending = 1;
+  }
 
   pthread_mutex_unlock(&bd->mutex);
-  if (ret)
+  if (ret && !bd->access_check_failed)
     goto rshim_map_failed;
 
   rshim_unlock();

--- a/src/rshim_usb.c
+++ b/src/rshim_usb.c
@@ -922,8 +922,10 @@ static int rshim_usb_probe_one(libusb_context *ctx, libusb_device *usb_dev,
 
   /* Notify that device is attached. */
   rc = rshim_notify(bd, RSH_EVENT_ATTACH, 0);
-  if (rc)
+  if (rc) {
+    pthread_mutex_unlock(&bd->mutex);
     goto error;
+  }
 
   if (rshim_force_mode && bd->drop_mode) {
     RSHIM_INFO("rshim%d will send force cmd to the other rshim-active end\n",

--- a/src/rshim_usb.c
+++ b/src/rshim_usb.c
@@ -70,7 +70,7 @@ static void rshim_usb_delete(rshim_backend_t *bd)
 {
   rshim_usb_t *dev = container_of(bd, rshim_usb_t, bd);
 
-  rshim_deregister(bd, true);
+  rshim_deregister(bd, false);
   RSHIM_INFO("rshim %s deleted\n", bd->dev_name);
   if (dev->handle) {
     libusb_close(dev->handle);

--- a/src/rshim_usb.c
+++ b/src/rshim_usb.c
@@ -70,7 +70,7 @@ static void rshim_usb_delete(rshim_backend_t *bd)
 {
   rshim_usb_t *dev = container_of(bd, rshim_usb_t, bd);
 
-  rshim_deregister(bd, false);
+  rshim_deregister(bd);
   RSHIM_INFO("rshim %s deleted\n", bd->dev_name);
   if (dev->handle) {
     libusb_close(dev->handle);
@@ -925,7 +925,7 @@ static int rshim_usb_probe_one(libusb_context *ctx, libusb_device *usb_dev,
   if (rc)
     goto error;
 
-  if (rshim_force_mode && bd->monitor_mode) {
+  if (rshim_force_mode && bd->drop_mode) {
     RSHIM_INFO("rshim%d will send force cmd to the other rshim-active end\n",
         bd->index);
     bd->force_cmd_pending = 1;


### PR DESCRIPTION
When Rshim driver finds another backend has attached to the rshim device, it
will enter drop mode. In this mode, user can echo a "FORCE_CMD 1" to
the misc file to request rshim ownership from the other backend.

Similarly, user can also send a one-time Force command using command option of
"--force", or setting "FORCE_CMD" to 1 in rshim.conf.

If Rshim driver is able to attach to the rshim device, it will monitor
the SP1 for incoming "RequestOwnership" command, and release rshim when
that command is found.

RM: 3679848
