### PR TITLE
bfb-install: fix for NIC mode

### DIFF
--- a/scripts/bfb-install
+++ b/scripts/bfb-install
@@ -520,7 +520,7 @@ cleanup() {
 
   # Bind driver back for NIC mode.
   if [ $is_nic_mode -eq 1 -a -n "$pcie_bdf" ]; then
-    echo "$pcie_bdf" > /sys/bus/pci/drivers/mlx5_core/bind >&/dev/null
+    echo "$pcie_bdf" > /sys/bus/pci/drivers/mlx5_core/bind
   fi
 }
 
@@ -777,9 +777,8 @@ fi
 # Check NIC mode and unbind mlx5_core driver in NIC mode.
 check_nic_mode
 if [ $is_nic_mode -eq 1 -a -n "$pcie_bdf" ]; then
-  echo "$pcie_bdf" > /sys/bus/pci/drivers/mlx5_core/unbind >&/dev/null &
+  echo "$pcie_bdf" > /sys/bus/pci/drivers/mlx5_core/unbind
 fi
-
 push_boot_stream
 
 wait_for_update_to_finish


### PR DESCRIPTION
Bing/Unbind mlx5_core driver output redirection synatx doesn't work The Unbind was trigger in background causing the driver to crash So therefore I remove the output redirection synatx and test it on baby-isr-1 and it works