### PR TITLE
Allow /dev/rshim<N> devfs creation only with --force option on

### DIFF
--- a/etc/rshim.conf
+++ b/etc/rshim.conf
@@ -21,8 +21,12 @@
 #DROP_MODE     0
 
 #
-# Once set to 1, the driver will try to force the other rshim driver using the
-# rshim to release it.
+# Once set to 1, the driver will be put rshim driver in ownership-forceable
+# mode. In this mode, the driver will send a one time ownership request command
+# to the other rshim backends upon start-up if the rshim interface is already
+# attached by another backend.  It also enables "/dev/rshim<N>/" creation even
+# when rshim is not attached, allowing user to manually send a ownership request
+# (aka FORCE_CMD) to "/dev/rshim<N>/misc" interface at any time.
 #
 # For example, if the current rshim driver is running from host via PCIe, but
 # the rshim device is already in use by the other rshim driver running from BMC

--- a/man/rshim.8
+++ b/man/rshim.8
@@ -36,10 +36,13 @@ Display the output
 cat /dev/rshim0/misc
     DISPLAY_LEVEL   0 (0:basic, 1:advanced, 2:log)
     BOOT_MODE       1 (0:rshim, 1:emmc, 2:emmc-boot-swap)
-    BOOT_TIMEOUT    100 (seconds)
+    BOOT_TIMEOUT    150 (seconds)
+    DROP_MODE       0 (0:normal, 1:drop)
     SW_RESET        0 (1: reset)
-    DEV_NAME        pcie-04:00.2
-    DEV_INFO        BlueField-1(Rev 0)
+    DEV_NAME        usb-1.1
+    DEV_INFO        BlueField-2(Rev 1)
+    OPN_STR         N/A
+    FORCE_CMD       0 (1: send Force command)
 .fi
 .in
 
@@ -108,7 +111,12 @@ Run in forground.
 
 -F, --force
 .in +4n
-Trying to force the other rshim driver to release the rshim device.
+Put rshim driver in ownership-forceable mode. In this mode, the driver will send
+a one time ownership request command to the other rshim backends upon start-up
+if the rshim interface is already attached by another backend.  It also enables
+"/dev/rshim<N>/" creation even when rshim is not attached, allowing user to
+manually send a ownership request (aka FORCE_CMD) to "/dev/rshim<N>/misc"
+interface at any time.
 
 For example, if the current rshim driver is running from host via PCIe, but the
 rshim device is already in use by the other rshim driver running from BMC via

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -2560,6 +2560,8 @@ int rshim_register(rshim_backend_t *bd)
   if (rc) {
     RSHIM_INFO("rshim%d entering drop mode\n", index);
     bd->drop_mode = 1;
+    if (!rshim_force_mode)
+      return rc;
   }
 
   if (!bd->write)


### PR DESCRIPTION
Make BMC happy by only creating the `/dev/rshim<N>` directory when running with `-F, --force` or configured such in `rshim.conf`.

RM #3987930