### PR TITLE
bfb-install: fix NIC_MODE installation for BF2

### DIFF
--- a/scripts/bfb-install
+++ b/scripts/bfb-install
@@ -370,11 +370,16 @@ push_boot_stream()
   fi
 }
 
+# Checks BF3 NIC_MODE
 check_nic_mode()
 {
   local str
 
   [ "$mode" != "local" ] && return
+
+  # Only needs to check for BF3.
+  str=`cat ${rshim_node}/misc | grep DEV_INFO | grep BlueField-3`
+  [ -z "$str" ] && return
 
   # Get PCIE BDF
   str=`cat ${rshim_node}/misc | grep DEV_NAME | awk '{print $2}'`


### PR DESCRIPTION
This commit fixes check_nic_mode() in the bfb-install script which is used to determination the completion of the installation and is only applicable to BF3.

RM #4005240