### PR TITLE
fix issue on Ubuntu that rshim service is masked after upgrade since 2.0.30

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -2,6 +2,9 @@
 set -e
 
 case "$1" in
+  # Unmask the service if it was previously masked.
+  # rshim service will be masked after "dpkg -i" or "apt remove" before 2.0.30
+  deb-systemd-helper unmask 'rshim.service' >/dev/null || true
   configure)
     echo "Installation complete. To enable and start the rshim service, run:"
     echo "  systemctl daemon-reload"


### PR DESCRIPTION
## Issue Description

1. In older version before 2.0.30, the debian/rules in the source code is written such that the rshim service is auto enabled. After installation, Ubuntu auto-generates these  files among others:

```
-rwxr-xr-x 1 root root 1251 Apr  5 10:41 /var/lib/dpkg/info/rshim.postinst*
-rwxr-xr-x 1 root root  642 Apr  5 10:41 /var/lib/dpkg/info/rshim.postrm*
-rwxr-xr-x 1 root root  206 Apr  5 10:41 /var/lib/dpkg/info/rshim.prerm*
```

The postrm will mask the service and postinst will unmask the service. So if the user run "apt remove", it will mask rshim but after running "apt install", it will be unmasked.

3. Then in 2.0.30, I introduced this change to disable rshim by default, With this change, the rshim deb package installation will no longer generate postrm and prerm. And the postinst no longer include unmasking because of my provided version:

**postinst in 2.0.25:**

```
root@bu-lab10v-06:~# cat /var/lib/dpkg/info/rshim.postinst
#!/bin/sh
set -e
# Automatically added by dh_systemd_enable/11.1.6ubuntu2
if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
        # This will only remove masks created by d-s-h on package removal.
        deb-systemd-helper unmask 'rshim.service' >/dev/null || true

        # was-enabled defaults to true, so new installations run enable.
        if deb-systemd-helper --quiet was-enabled 'rshim.service'; then
                # Enables the unit on first installation, creates new
                # symlinks on upgrades if the unit file has changed.
                deb-systemd-helper enable 'rshim.service' >/dev/null || true
        else
                # Update the statefile to add new symlinks (if any), which need to be
                # cleaned up on purge. Also remove old symlinks.
                deb-systemd-helper update-state 'rshim.service' >/dev/null || true
        fi
fi
# End automatically added section
# Automatically added by dh_systemd_start/11.1.6ubuntu2
if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
        if [ -d /run/systemd/system ]; then
                systemctl --system daemon-reload >/dev/null || true
                deb-systemd-invoke start 'rshim.service' >/dev/null || true
        fi
fi
# End automatically added section
```

**postinst in 2.0.30:**

```
root@bu-lab10v-06:~# cat /var/lib/dpkg/info/rshim.postinst
#!/bin/sh
set -e

case "$1" in
  configure)
    echo "Installation complete. To enable and start the rshim service, run:"
    echo "  systemctl daemon-reload"
    echo "  systemctl enable rshim"
    echo "  systemctl start rshim"
    ;;
esac
```

5. The problem happens when the user first installs old versions like 2.0.25, then removes it by "apt remove", and then install new versions like 2.0.30. Since the "apt remove" still causes the rshim to be masked, and the new postinst doesn't unmask it, the end result is the 2.0.30 installation will fail since the rshim is now masked after installation.

We could have told user to uninstall the package by using "apt purge", but that's against their long time habit. The better option is to update our new debin/postinst in 2.0.30 to include the default unmasking behavior.