### PR TITLE
Fix premature bfb-install exit when rebooting BMC

### DIFF
--- a/scripts/bfb-install
+++ b/scripts/bfb-install
@@ -408,7 +408,7 @@ wait_for_update_to_finish()
   # the exit condition of the bfb-install script.
   local filter0 filter
 
-  filter0="Reboot|finished|DPU is ready|Linux up"
+  filter0="Rebooting\.\.\.|finished|DPU is ready|Linux up"
   if [ $runtime -eq 0 ]; then
     filter0="$filter0|In Enhanced NIC mode"
   else


### PR DESCRIPTION
Prevent bfb-install exit filter to match "Rebooting BMC.." string.

RM #4047597