### PR TITLE
Increase default boot timeout to 300s

### DIFF
--- a/etc/rshim.conf
+++ b/etc/rshim.conf
@@ -11,7 +11,7 @@
 # Timeout in seconds when pushing BFB while target side is not reading the
 # boot stream
 #
-#BOOT_TIMEOUT  200
+#BOOT_TIMEOUT  300
 
 #
 # Once set to 1, the driver will ignore all rshim writes and returns 0 for

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -212,7 +212,7 @@ char *rshim_static_dev_name;
 /* Default configuration file. */
 const char *rshim_cfg_file = DEFAULT_RSHIM_CONFIG_FILE;
 static int rshim_display_level;
-static int rshim_boot_timeout = 200;
+static int rshim_boot_timeout = 300;
 int rshim_drop_mode = -1;
 int rshim_usb_reset_delay = 1;
 bool rshim_has_usb_reset_delay;


### PR DESCRIPTION
The 'BOOT_TIMEOUT' configuration parameter is used to detect ARM stuck/crash when it hasn't polled the boot FIFO for such time. It's found in a certain server that redfish related activities could pause reading boot stream for more than 200s. Adjust the default value to prevent such error.

RM #3830033