### PR TITLE
configure: fix fuse errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,12 +86,12 @@ AS_IF([test "x$build_fuse" = "xyes"], [
     AC_CHECK_LIB(cuse, cuse_dev_create)
   else
     PKG_CHECK_MODULES(fuse, fuse, [], PKG_CHECK_MODULES(fuse, fuse3, [use_fuse3=yes], [AC_MSG_ERROR([Can't find fuse])]))
-  if test $use_fuse3 = yes; then
+  fi
+  if test "x$use_fuse3" = "xyes"; then
     AC_SUBST(CPPFLAGS, "$CPPFLAGS -DFUSE_USE_VERSION=30")
   else
     AC_SUBST(CPPFLAGS, "$CPPFLAGS -DFUSE_USE_VERSION=29")
   fi
-fi
 ])
 
 if test $backend = freebsd; then


### PR DESCRIPTION
Fix the following syntax errors:
  ...
 checking for fuse... yes
 ./configure: line 5243: test: =: unary operator expected
 checking for pthread_create in -lpthread... yes
 checking that generated files are newer than configure... done
 configure: creating ./config.status
  ...

I will not check it for Freebsd or other OS, but there is obviously something wrong with the syntax.