### PR TITLE
Use BOOT_RESET_SKIP command to simulate eMMC boot

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -769,14 +769,16 @@ int rshim_boot_open(rshim_backend_t *bd)
   /* Reset the TmFifo. */
   rshim_fifo_reset(bd);
 
-  /* Set RShim (external) boot mode. */
-  rc = bd->write_rshim(bd, RSHIM_CHANNEL, bd->regs->boot_control,
-                       RSH_BOOT_CONTROL__BOOT_MODE_VAL_NONE, RSHIM_REG_SIZE_8B);
-  if (rc) {
-    RSHIM_ERR("rshim%d boot failed to write boot control(%d)\n", bd->index, rc);
-    bd->is_booting = 0;
-    pthread_mutex_unlock(&bd->mutex);
-    return rc;
+  if (!bd->skip_boot_reset) {
+    /* Set RShim (external) boot mode. */
+    rc = bd->write_rshim(bd, RSHIM_CHANNEL, bd->regs->boot_control,
+                         RSH_BOOT_CONTROL__BOOT_MODE_VAL_NONE, RSHIM_REG_SIZE_8B);
+    if (rc) {
+      RSHIM_ERR("rshim%d boot failed to write boot control(%d)\n", bd->index, rc);
+      bd->is_booting = 0;
+      pthread_mutex_unlock(&bd->mutex);
+      return rc;
+    }
   }
 
   bd->is_boot_open = 1;


### PR DESCRIPTION
The 'BOOT_RESET_SKIP' debug command is used to skip ARM reset when pushing a BFB, which is used during palladium test to save reboot time. With minor change to skip the automatic 'BOOT_MODE' setting as well, this command can be used to simulate eMMC boot which could be very useful to upgrade preboot BSP in NIC mode because it doesn't requires power-cycle after the upgrade.

Below are steps example to push preboot_install.bfb in NIC mode without affecting DRAM allocation:

echo "BOOT_MODE 0" > /dev/rshim0/misc
echo "SW_RESET 1" > /dev/rshim0/misc
echo "BOOT_MODE 1" > /dev/rshim0/misc
echo "BOOT_RESET_SKIP 1" > /dev/rshim0/misc
cat preboot_install.bfb > /dev/rshim0/boot
echo "BOOT_RESET_SKIP 0" > /dev/rshim0/misc

RM #4134329