### PR TITLE
Update default USB timeout

### DIFF
--- a/etc/rshim.conf
+++ b/etc/rshim.conf
@@ -17,7 +17,7 @@
 # Timeout in seconds for libusb operations. May need to be increased when
 # writing to rshim "boot" device file exits prematurely.
 #
-#USB_TIMEOUT  20
+#USB_TIMEOUT  40
 
 #
 # Once set to 1, the driver will ignore all rshim writes and returns 0 for

--- a/src/rshim.h
+++ b/src/rshim.h
@@ -248,7 +248,7 @@ typedef struct {
 #define BLUEFIELD_REV1 1
 
 /* Timeout for libusb operations in seconds. */
-#define RSHIM_USB_TIMEOUT  20
+#define RSHIM_USB_TIMEOUT  40
 
 /* RShim backend. */
 typedef struct rshim_backend rshim_backend_t;


### PR DESCRIPTION
This commit updates the default USB timeout to workaround an issue with curl not handling the returning error code when using command 'curl xxx -o /dev/rshim0/boot' to inject the boot stream while BlueField SoC is busying for more than 20 seconds.

RM #4128189