### PR TITLE
USB: removes the unnecessary POLLOUT polling

### DIFF
--- a/src/rshim_usb.c
+++ b/src/rshim_usb.c
@@ -1058,7 +1058,6 @@ static int rshim_usb_add_poll(libusb_context *ctx)
 } while (0)
 
   RSHIM_CONVERT(POLLIN);
-  RSHIM_CONVERT(POLLOUT);
 #ifdef __linux__
   RSHIM_CONVERT(POLLRDNORM);
   RSHIM_CONVERT(POLLRDBAND);


### PR DESCRIPTION
USB output is either done in synchronous or interactive way, thus no need for POLLOUT polling. It'll save quite a bit of CPU cycle usage expecially during idle. This commit also added a check do to locked mode checking only for rshim over PCIe.

RM ##4193076