### PR TITLE
Add option '-e' to enable exit on bfb push errors

### DIFF
--- a/man/rshim.8
+++ b/man/rshim.8
@@ -3,7 +3,17 @@
 .SH NAME
 rshim \- user-space rshim driver for BlueField SoC
 .SH SYNOPSIS
-rshim [options]
+rshim
+    [-b, --backend <usb|pcie|pcie_lf>]
+    [-c, --cmdmode <-g, --get-debug | -s, --set-debug <0|1>>]
+    [-d, --device <device>]
+    [-e, --exit-on-error]
+    [-f, --foreground]
+    [-F, --force]
+    [-i, --index <index>]
+    [-l, --log-level <log_level>]
+    [-v, --version]
+
 .SH DESCRIPTION
 rshim is the user-space rshim driver for BlueField SoC. It provides ways to access the rshim resources on the BlueField target via USB or PCIe from external host machine. The current version implements virtual console, virtual network interface, boot stream push, register access and some utility commands.
 
@@ -121,9 +131,18 @@ Specify the device name to attach with the format below. The backend driver can 
         Devices can be found under /sys/bus/usb/devices/.
 .in
 
+-e,--exit-on-error
+.in +4n
+Exit on error. By default, the driver will continue to run even if an error occurs.
+
+The following error cases will cause the driver to exit:
+
+* When running `rshim -d` from host and when rshim encounters errors that could cause client bfb push failures, like rshim failing to attach to the PCIe backend
+.in
+
 -f, --foreground
 .in +4n
-Run in forground.
+Run in foreground.
 .in
 
 -F, --force

--- a/src/rshim.c
+++ b/src/rshim.c
@@ -250,6 +250,7 @@ bool rshim_no_net;
 int rshim_log_level = LOG_NOTICE;
 bool rshim_daemon_mode = true;
 volatile bool rshim_run = true;
+bool rshim_exit_on_error = false;
 
 /* rshim stop semaphore. */
 sem_t rshim_stop_sem;
@@ -2939,7 +2940,7 @@ static void rshim_main(int argc, char *argv[])
   }
   if (rc) {
     RSHIM_ERR("Failed to initialize rshim backend\n");
-    exit(-1);
+    exit(ENODEV);
   }
 
   /* Run command mode if specified. */
@@ -3316,11 +3317,12 @@ static void print_help(void)
 
 int main(int argc, char *argv[])
 {
-  static const char short_options[] = "b:cd:fgFhi:l:nsv";
+  static const char short_options[] = "b:cd:efgFhi:l:nsv";
   static struct option long_options[] = {
     { "backend", required_argument, NULL, 'b' },
     { "cmdmode", no_argument, NULL, 'c' },
     { "device", required_argument, NULL, 'd' },
+    { "exit-on-error", no_argument, NULL, 'e' },
     { "foreground", no_argument, NULL, 'f' },
     { "force", no_argument, NULL, 'F' },
     { "get-debug", no_argument, NULL, 'g' },
@@ -3350,6 +3352,9 @@ int main(int argc, char *argv[])
       break;
     case 'd':
       rshim_static_dev_name = optarg;
+      break;
+    case 'e':
+      rshim_exit_on_error = true;
       break;
     case 'f':
       rshim_daemon_mode = false;

--- a/src/rshim.h
+++ b/src/rshim.h
@@ -52,6 +52,7 @@ extern int rshim_pcie_enable_uio;
 extern bool rshim_force_cmd_pending[];
 extern bool rshim_cmdmode;
 extern int rshim_static_index;
+extern bool rshim_exit_on_error;
 
 #ifndef offsetof
 #define offsetof(TYPE, MEMBER)	((size_t)&((TYPE *)0)->MEMBER)

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -58,9 +58,12 @@ static void rshim_fuse_boot_open(fuse_req_t req, struct fuse_file_info *fi)
   if (bd)
     rc = rshim_boot_open(bd);
 
-  if (rc)
+  if (rc) {
     fuse_reply_err(req, -rc);
-  else
+    RSHIM_ERR("rshim%d failed to open boot device (%d)\n", bd->index, rc);
+    if (rshim_exit_on_error)
+      exit(-rc);
+  } else
     fuse_reply_open(req, fi);
 }
 #elif defined(__FreeBSD__)
@@ -103,8 +106,12 @@ static void rshim_fuse_boot_write(fuse_req_t req, const char *user_buffer,
 
   if (rc >= 0)
     fuse_reply_write(req, rc);
-  else
+  else {
     fuse_reply_err(req, -rc);
+    RSHIM_ERR("rshim%d failed to write to boot device (%d)\n", bd->index, rc);
+    if (rshim_exit_on_error)
+      exit(-rc);
+  }
 }
 #elif defined(__FreeBSD__)
 static int rshim_fuse_copy_in(void *dest, const void *src, int count)


### PR DESCRIPTION
    This change doesn't change the default rshim behavior. When the new '-e'
    option is enabled, the following specific use cases will cause rshim to
    exit:

    * Rshim is running from host with "-d” option, and
    * Errors happen in bfb-push that are detectable by rshim, including:
      - Backend attach failure ("another backend already attached")
      - Rshim "boot" devie file open failure (like when rshim is in drop
        mode or locked mode)
      - Writing to "boot" device file failure during bfb push

    Example:

    $ sudo ./src/rshim -f -l 3 -d pcie-0000:b1:00.2  --exit-on-error
    $ sudo ./src/rshim -f -l 3 -d pcie-0000:b1:00.2  --e

    Note: Not all bfb-push errors are detectable by rshim as it’s handled
    by upper layer)

    RM #4184083