### PR TITLE
Add GitHub pipeline to create deb/rpm packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,168 @@
+---
+#
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+
+name: CI/CD pipeline for rshim - deb and rpm for amd64 and arm64
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install dependencies (for .deb)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential debhelper devscripts fakeroot git \
+            libpci-dev libusb-1.0-0-dev libfuse-dev pkg-config
+
+      - name: Prepare release body
+        id: changelog
+        run: |
+          body=$(./scripts/get-changelog debian/changelog)
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo "${body}" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create source tarball
+        run: |
+          [ -d dist ] || mkdir -p dist
+          version="$(./scripts/get-ver)"
+          tarball="rshim-src-${version}.tar.gz"
+          git archive --format=tar.gz -o "$tarball" HEAD
+          mv -v "$tarball" dist/
+          ls -lh dist
+
+      - name: Build & Test x86_64 .deb package
+        run: |
+          version="$(./scripts/get-ver)"
+          sed -i "1s/(\(.*\))/($version)/" debian/changelog
+          DEB_BUILD_OPTIONS="nocheck nostrip" dpkg-buildpackage \
+            -us -uc -a amd64
+          mkdir -p dist
+          mv -v ../*.deb dist/
+          ls -lh dist
+          sudo dpkg -i dist/*.deb || sudo apt-get -f install -y
+          echo "Running rshim --version:"
+          rshim --version
+
+      - name: Capture UID/GID for Docker
+        id: uidgid
+        run: |
+          echo "HOST_UID=$(id -u)" >> $GITHUB_ENV
+          echo "HOST_GID=$(id -g)" >> $GITHUB_ENV
+
+      - name: Build & Test ARM64 .deb package in Docker
+        run: |
+          docker run --rm --privileged multiarch/qemu-user-static \
+            --reset -p yes
+
+          docker run --rm --platform linux/arm64 \
+            -e HOST_UID="${{ env.HOST_UID }}" \
+            -e HOST_GID="${{ env.HOST_GID }}" \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            arm64v8/ubuntu:22.04 \
+            /bin/bash -c "
+              apt-get update && \
+              apt-get install -y build-essential debhelper devscripts \
+                fakeroot gcc git libpci-dev libusb-1.0-0-dev libfuse-dev \
+                pkg-config && \
+              git config --global --add safe.directory /workspace && \
+              version=\$(/workspace/scripts/get-ver) && \
+              sed -i \"1s/(\(.*\))/(\$version)/\" \
+                /workspace/debian/changelog && \
+              mkdir -p /workspace/build && \
+              DEB_BUILD_OPTIONS='nocheck nostrip' dpkg-buildpackage \
+                -us -uc -a arm64 && \
+              mv -v ../*.deb /workspace/build/ && \
+              apt-get install -y libpci3 libusb-1.0-0 fuse || true && \
+              dpkg -i /workspace/build/*.deb || apt-get -f install -y && \
+              echo 'Running rshim --version:' && \
+              rshim --version && \
+              chown -R \$HOST_UID:\$HOST_GID /workspace
+            "
+          mkdir -p dist
+          mv -v build/*.deb dist/
+          ls -lh dist
+
+      - name: Build & Test x86_64 RPM using Rocky Linux
+        run: |
+          docker run --rm \
+            -e HOST_UID="${{ env.HOST_UID }}" \
+            -e HOST_GID="${{ env.HOST_GID }}" \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            quay.io/rockylinux/rockylinux:8 \
+            /bin/bash -c "
+              yum -y install gcc make rpm-build git autoconf automake \
+                libtool pkgconfig pciutils-devel libusb1-devel fuse-devel && \
+              git config --global --add safe.directory /workspace && \
+              ARCH=x86_64 ./scripts/build-rpm && \
+              yum localinstall -y /workspace/rpmbuild/RPMS/x86_64/*.rpm && \
+              echo 'Running rshim --version:' && \
+              rshim --version && \
+              chown -R \$HOST_UID:\$HOST_GID /workspace
+            "
+          mkdir -p dist
+          mv -v $(find rpmbuild/RPMS -name '*.rpm') dist/
+          ls -lh dist
+
+      - name: Build & Test arm64 RPM using Rocky Linux
+        run: |
+          docker run --rm --privileged multiarch/qemu-user-static \
+            --reset -p yes
+          docker run --rm --platform linux/arm64 \
+            -e HOST_UID="${{ env.HOST_UID }}" \
+            -e HOST_GID="${{ env.HOST_GID }}" \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            quay.io/rockylinux/rockylinux:8 \
+            /bin/bash -c "
+              yum -y install gcc make rpm-build git autoconf automake \
+                libtool pkgconfig pciutils-devel libusb1-devel fuse-devel && \
+              git config --global --add safe.directory /workspace && \
+              ARCH=aarch64 ./scripts/build-rpm && \
+              yum localinstall -y /workspace/rpmbuild/RPMS/aarch64/*.rpm && \
+              echo 'Running rshim --version:' && \
+              rshim --version && \
+              chown -R \$HOST_UID:\$HOST_GID /workspace
+            "
+          mkdir -p dist
+          mv -v $(find rpmbuild/RPMS -name '*.rpm') dist/
+          ls -lh dist
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: rshim-packages
+          path: dist/*
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref_name, 'rshim-')
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.body }}
+          draft: false
+          prerelease: false
+          artifacts: |
+            dist/*

--- a/scripts/build-rpm
+++ b/scripts/build-rpm
@@ -1,0 +1,54 @@
+#!/bin/sh -e
+#
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+#
+# Build rpm package for rshim driver for x86_64 and aarch64.
+# The script generates source rpm, then builds x86_64 or aarch64 rpm depending
+# on the CPU platform it's running on.
+#
+# Must run from the root of the rshim source tree.
+#
+# Usage:
+#   ./script/build-rpm
+#
+
+topdir=$(pwd)/rpmbuild
+[ -d $topdir ] && rm -rf $topdir
+mkdir -p $topdir/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+
+# Generate rshim.spec
+./bootstrap.sh
+./configure
+make
+cp rshim.spec $topdir/SPECS/
+
+# Generate source tarball
+rm -f *.tar.gz
+ver_tag=$(grep "^Version:" rshim.spec | cut -d' ' -f2)
+tarball="rshim-${ver_tag}.tar.gz"
+git archive --prefix="rshim-${ver_tag}/" --format=tar.gz -o "$tarball" HEAD
+mv $tarball $topdir/SOURCES/
+
+#
+# Generate source RPM
+#
+rpmbuild --define "_topdir ${topdir}" -bs $topdir/SPECS/rshim.spec
+src_rpm=$(echo $topdir/SRPMS/rshim-*.src.rpm)
+if [ ! -e "${src_rpm}" ]; then
+  echo "${src_rpm} not found"
+  exit 1
+fi
+
+#
+# Build rshim RPM
+#
+rpmbuild --define "_topdir ${topdir}" --rebuild ${src_rpm}
+version="$(./scripts/get-ver)"
+arch=$(uname -m)
+arch_rpm=$(echo ${topdir}/RPMS/${arch}/rshim*.rpm)
+if [ -f "$arch_rpm" ]; then
+  rpm_file=rshim-${version}_${arch}.rpm
+  mv $arch_rpm ${topdir}/RPMS/${arch}/$rpm_file
+  echo "${arch} RPM: $rpm_file"
+fi

--- a/scripts/get-changelog
+++ b/scripts/get-changelog
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Parse the top entry of debian/changelog and build a release note.
+#
+# Usage:
+#   ./make_release_body.sh debian/changelog
+#
+# Output:
+#   Prints the release body to stdout.
+
+CHANGELOG_FILE="$1"
+[ -z "$CHANGELOG_FILE" ] && {
+  echo "Usage: $0 debian/changelog"
+  exit 1
+}
+
+awk '
+  BEGIN {
+    top_version = ""
+    second_version = ""
+    in_top_entry = 0
+  }
+
+  # Match lines like: rshim (2.2.1) ...
+  # Extract the version inside parentheses.
+  # The first occurrence is top_version, the second is second_version.
+  /^rshim \(/ {
+    # Extract version from: rshim (X.Y.Z) ...
+    match($0, /^rshim \(([^)]+)\)/, arr)
+    this_version = arr[1]
+
+    if (top_version == "") {
+      top_version = this_version
+      in_top_entry = 1
+      next
+    } else if (second_version == "") {
+      second_version = this_version
+      # As soon as we see the second version, we can stop collecting.
+      # Because that means the top entry ends right before this line.
+      exit
+    }
+  }
+
+  # While we are in the top entry, collect the bullet points until we see -- or the next version.
+  in_top_entry == 1 {
+    # If we see a line starting with --, it means the top entry ended.
+    if ($0 ~ /^ -- /) {
+      in_top_entry = 0
+      next
+    }
+    # Otherwise, collect the lines (these are the bullet points).
+    top_entry_text = top_entry_text $0 "\n"
+  }
+
+  END {
+    # If we never found a second_version, set it to something to avoid blank output.
+    if (second_version == "") {
+      second_version = "previous"
+    }
+
+    print "## Changelog (" top_version " compared to " second_version "):\n" top_entry_text
+  }
+' "$CHANGELOG_FILE"

--- a/scripts/get-ver
+++ b/scripts/get-ver
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# This script generates a version string based on the latest Git tag and branch.
+#
+# Usage:
+#   ./get-ver         Outputs a simplified version for a release when on a tag.
+#   ./get-ver -v      Outputs the full version string with commit count and hash.
+# Output formats:
+#   Simplified: "X.Y.Z" (when the commit matches a tag and no options are passed)
+#   Full: "X.Y.Z-N-g<commit-hash>" (always, or with -v option)
+
+# Function to generate the version string
+generate_version() {
+  local current_branch
+  current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+  # Find the latest tag matching "rshim-X.Y.Z" merged into the current branch
+  local latest_tag
+  latest_tag=$(git tag --list "rshim-[0-9]*.[0-9]*.[0-9]*" --merged "$current_branch" | sort -V | tail -n 1)
+
+  # Generate the full version string
+  local version
+  version=$(git describe --always --tags --match "$latest_tag" --long)
+  version=${version#rshim-} # Remove the "rshim-" prefix
+
+  # Extract components of the version string
+  local base_version commit_count commit_hash
+  base_version=$(echo "$version" | cut -d- -f1)      # "X.Y.Z"
+  commit_count=$(echo "$version" | cut -d- -f2)      # "N"
+  commit_hash=$(echo "$version" | cut -d- -f3)       # "g<commit-hash>"
+
+  # Simplified version output when commit is at the tag
+  if [[ "$commit_count" == "0" ]] && [[ "$1" != "-v" ]]; then
+    echo "$base_version"
+  else
+    echo "$base_version-$commit_count-$commit_hash"
+  fi
+}
+
+if [[ "$1" == "-v" ]]; then
+  generate_version -v
+else
+  generate_version
+fi


### PR DESCRIPTION
- Every commit will cause a pipeline to run.
- The pipeline do the following for each type (x64/arm64 deb/rpm):
  - Build the deb/rpm
  - Test the deb/rpm:
    - Run the deb/rpm installation
    - Run `rshim --version` to check instalation
- Artifacts can be downloaded from the link in the pipeline log
- A tag push will additionaly cause a release to be build and shown in the Release page at: https://github.com/Mellanox/rshim-user-space/releases

RM #4194972