### PR TITLE
Fix RPM dependency on Oracle Linux 8.6

### DIFF
--- a/rshim.spec.in
+++ b/rshim.spec.in
@@ -15,7 +15,7 @@ Source0: https://github.com/mellanox/rshim-user-space/archive/%{name}-%{version}
 BuildRequires: gcc, autoconf, automake, pkgconfig, make
 BuildRequires: pkgconfig(libpci), pkgconfig(libusb-1.0)
 
-%if (0%{?oraclelinux} >= 8)
+%if (0%{?oraclelinux} >= 9)
 Requires: kernel-uek-core
 %else
 %if (0%{?rhel} >= 8 || 0%{?fedora} > 0) && "0%{?ctyunos}" == "0"


### PR DESCRIPTION
Commit 69815e92738f adjusts the dependency to use kernel-uek-core, but it is only available since UEK Release 7. Thus the RPM install is broken in racle Linux 8.6 which uses UEK Release 6. This commit adjusts to use kernel-uek-core since Oracle Linux 9. For Oracle Linux 8, kernel-modules-extra still exists which contains the cuse module.

RM #4253481