### PR TITLE
Enhance command line for register read/write

### DIFF
--- a/man/rshim.8
+++ b/man/rshim.8
@@ -100,6 +100,9 @@ Run rshim as command line rather than as driver. The following sub-commands are 
     -g, --get-debug
     Get the current debug setting.
 
+    -r, --reg <addr.[32|64] [value]>
+    Read/write registers.
+
     -s, set-debug <0 | 1>
     Set the debug setting.
 .in

--- a/src/rshim.h
+++ b/src/rshim.h
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mount.h>
 #include <termios.h>
 #include <unistd.h>
 #ifdef HAVE_CONFIG_H
@@ -500,6 +501,27 @@ struct rshim_regs {
   uint32_t scratch_buf_ctl;
 };
 
+/* Ioctl() message header. */
+typedef struct {
+  uint32_t addr;
+  uint64_t data;
+} __attribute__((packed)) rshim_ioctl_msg;
+
+/* Ioctl() message header with size. */
+typedef struct {
+  uint32_t addr;
+  uint64_t data;
+  uint8_t data_size;
+} __attribute__((packed)) rshim_ioctl_msg2;
+
+/* Ioctl() code. */
+enum {
+  RSHIM_IOC_READ = _IOWR('R', 0, rshim_ioctl_msg),
+  RSHIM_IOC_WRITE = _IOWR('R', 1, rshim_ioctl_msg),
+  RSHIM_IOC_READ2 = _IOWR('R', 0, rshim_ioctl_msg2),
+  RSHIM_IOC_WRITE2 = _IOWR('R', 1, rshim_ioctl_msg2),
+};
+
 extern const struct rshim_regs bf1_bf2_rshim_regs;
 extern const struct rshim_regs bf3_rshim_regs;
 
@@ -659,5 +681,8 @@ int rshim_set_drop_mode(rshim_backend_t *bd, int value);
 
 /* Run rshim command mode. */
 int rshim_cmdmode_run(int argc, char *argv[]);
+
+/* Common initialization. */
+int rshim_init(int *epoll_fd, int *timer_fd);
 
 #endif /* _RSHIM_H */

--- a/src/rshim_cmdmode.c
+++ b/src/rshim_cmdmode.c
@@ -11,21 +11,82 @@
 
 #include "rshim.h"
 
-static int rshim_getset_debug(rshim_backend_t *bd, bool get, uint32_t *setting)
+int rshim_cmd_fd = -1;
+rshim_backend_t *rshim_cmd_bd = NULL;
+
+/* Register read/write via /dev/rshim<N>/rshim. */
+static int rshim_fd_rw(uint32_t chan, uint32_t addr, uint64_t *value,
+                       int size, bool read)
+{
+  rshim_ioctl_msg2 msg;
+  int rc, fd = rshim_cmd_fd;
+
+  if (fd == -1)
+    return -ENODEV;
+
+  msg.addr = ((uint64_t)chan << 16) | addr;
+  msg.data = read ? 0 : *value;
+  msg.data_size = size;
+
+  if (read) {
+    rc = ioctl(fd, RSHIM_IOC_READ2, &msg);
+    if (!rc)
+      *value = msg.data;
+  } else {
+    rc = ioctl(fd, RSHIM_IOC_WRITE2, &msg);
+  }
+
+  return rc;
+}
+
+/* Register read/write via a dummy backend. */
+static int rshim_bd_rw(uint32_t chan, uint32_t addr, uint64_t *value,
+                       int size, bool read)
+{
+  rshim_backend_t *bd = rshim_cmd_bd;
+  int rc;
+
+  if (!bd)
+    return -ENODEV;
+
+  pthread_mutex_lock(&bd->mutex);
+
+  if (read)
+    rc = bd->read_rshim(bd, chan, addr, value, size);
+  else
+    rc = bd->write_rshim(bd,chan, addr, *value, size);
+
+  pthread_mutex_unlock(&bd->mutex);
+
+  return rc;
+}
+
+/* Register read/write. */
+static int rshim_rw(uint32_t chan, uint32_t addr, uint64_t *value,
+                    int size, bool read)
+{
+  if (rshim_cmd_bd)
+    return rshim_bd_rw(chan, addr, value, size, read);
+  else if (rshim_cmd_fd >= 0)
+    return rshim_fd_rw(chan, addr, value, size, read);
+  else
+    return -ENODEV;
+}
+
+/* Enable/Disable UEFI debug. */
+static int rshim_uefi_debug(bool read, uint64_t *setting)
 {
   uint64_t value = 0;
   int rc;
 
-  pthread_mutex_lock(&bd->mutex);
-
-  rc = bd->read_rshim(bd, RSHIM_CHANNEL, RSH_BREADCRUMB1, &value,
-                      RSHIM_REG_SIZE_8B);
+  rc = rshim_rw(RSHIM_CHANNEL, RSH_BREADCRUMB1, &value,
+                RSHIM_REG_SIZE_8B, true);
   if (rc) {
-    RSHIM_ERR("Failed to read debug setting (0x%x)\n", rc);
+    printf("Failed to read debug setting (0x%x)\n", rc);
     return -1;
   }
 
-  if (get) {
+  if (read) {
     *setting = (value & RSH_BREADCRUMB1_DBG_ENABLE_MASK) ? 1 : 0;
   } else {
     if (*setting)
@@ -34,60 +95,130 @@ static int rshim_getset_debug(rshim_backend_t *bd, bool get, uint32_t *setting)
       value &= ~RSH_BREADCRUMB1_DBG_ENABLE_MASK;
   }
 
-  rc = bd->write_rshim(bd, RSHIM_CHANNEL, RSH_BREADCRUMB1, value,
-                       RSHIM_REG_SIZE_8B);
-
-  pthread_mutex_unlock(&bd->mutex);
+  rc = rshim_rw(RSHIM_CHANNEL, RSH_BREADCRUMB1, &value,
+                RSHIM_REG_SIZE_8B, false);
 
   return 0;
 }
 
+/* Read 64-bit number from string. */
+static int string_read64(const char *str, uint64_t *value)
+{
+  char *endptr;
+
+  if (!str || !*str || !value)
+    return -EINVAL;
+
+  errno = 0;
+  *value = strtoll(str, &endptr, 0);
+
+  return (errno || endptr == str) ? -EINVAL : 0;
+}
+
 int rshim_cmdmode_run(int argc, char *argv[])
 {
-  static const char short_options[] = "cgs:";
+  static const char short_options[] = "cgi:r:s:";
   static struct option long_options[] = {
     { "get-debug", no_argument, NULL, 'g' },
+    { "index", required_argument, NULL, 'i' },
+    { "reg", required_argument, NULL, 'r' },
     { "set-debug", required_argument, NULL, 's' },
     { NULL, 0, NULL, 0 }
   };
-  int c, rc = 0, index = 0;
-  uint32_t setting = 0;
-  rshim_backend_t *bd;
+  uint64_t addr = 0, value = 0;
+  int c, rc = 0, size;
+  char tmp[64], *p;
 
-  /* Use the backend if specified. */
-  if (rshim_static_index > 0)
-    index = rshim_static_index;
+  /*
+   * Use the backend if specified, or else try to create the USB backend
+   * which is mainly for DPU BMC.
+   */
+  if (rshim_static_index >= 0) {
+    sprintf(tmp, "/dev/rshim%d/rshim", rshim_static_index);
+    rshim_cmd_fd = open(tmp, O_RDWR | O_SYNC);
+    if (rshim_cmd_fd == -1) {
+      printf("Can't open rshim\n");
+      return -ENODEV;
+    }
+  } else {
+    rc = rshim_init(NULL, NULL);
+    if (rc) {
+      printf("rshim_init failed\n");
+      return rc;
+    }
 
-  rshim_lock();
+    rc = rshim_usb_init(rshim_epoll_fd);
+    if (rc) {
+      perror("USB:");
+      return rc;
+    }
 
-  bd = rshim_find_by_index(index);
-  if (!bd) {
-    rc = -ENODEV;
-    goto done;
+    rshim_cmd_bd = rshim_find_by_index(0);
+    if (!rshim_cmd_bd) {
+      printf("Can't find rshim\n");
+      return -ENODEV;
+    }
   }
 
-  /* Reset the getopt() parsing. */
-  optind = 1;
-
   /* Parse arguments. */
-  while ((c = getopt_long(argc, argv, short_options, long_options, NULL))
+  optind = 1;
+  while ((c = getopt_long(argc, argv, short_options, long_options, &optind))
          != -1) {
     switch (c) {
     case 'g':
-      rc = rshim_getset_debug(bd, true, &setting);
+      rc = rshim_uefi_debug(true, &value);
       if (rc) {
         printf("--get-debug failed\n");
-        goto done;
+        return rc;
       }
-      printf("0x%x\n", setting);
+      printf("0x%llx\n", (unsigned long long)value);
       break;
 
     case 's':
-      setting = atoi(optarg);
-      rc = rshim_getset_debug(bd, false, &setting);
+      value = atol(optarg);
+      rc = rshim_uefi_debug(false, &value);
       if (rc) {
         printf("--set-debug failed\n");
-        goto done;
+        return rc;
+      }
+      break;
+
+    case 'r':
+      /* Syntax: <addr.[32|64]> [value] */
+      strncpy(tmp, (char *)optarg, sizeof(tmp) - 1);
+      p = strchr(tmp, '.');
+      if (!p)
+        return -EINVAL;
+      *p++ = 0;
+      size = atoi(p);
+      if (size != 32 && size != 64)
+        return -EINVAL;
+
+      rc = string_read64(tmp, &addr);
+      if (rc)
+        break;
+      if (optind < argc) {
+        /* write */
+        rc = string_read64(argv[optind], &value);
+        if (rc)
+          break;
+
+        rc = rshim_rw((uint32_t)addr >> 16, addr & 0xFFFF, &value,
+                      size / 8, false);
+        if (rc)
+          return rc;
+
+        printf("[0x%llx] <- 0x%016llx\n", (unsigned long long)addr,
+               (unsigned long long)value);
+      } else {
+        /* read */
+        rc = rshim_rw((uint32_t)addr >> 16, addr & 0xFFFF, &value,
+                      size / 8, true);
+        if (rc)
+          return rc;
+
+        printf("[0x%llx] -> 0x%016llx\n", (unsigned long long)addr,
+               (unsigned long long)value);
       }
       break;
 
@@ -96,10 +227,9 @@ int rshim_cmdmode_run(int argc, char *argv[])
     }
   }
 
-done:
-  rshim_unlock();
-  if (rc)
-    printf("Command failed (%d)\n", rc);
+  /* Cleanup */
+  if (rshim_cmd_fd != -1)
+    close(rshim_cmd_fd);
 
   return rc;
 }

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -1091,28 +1091,6 @@ static const struct cuse_methods rshim_misc_fops = {
 
 /* Rshim file operations routines */
 
-/* ioctl message header. */
-typedef struct {
-  uint32_t addr;
-  uint64_t data;
-} __attribute__((packed)) rshim_ioctl_msg;
-
-/* ioctl message header for Mustang. Unlike BF1 and BF2, Mustang
- * HW enables different USB transfer sizes: 1B, 2B, 4B and 8B.
- */
-typedef struct {
-  uint32_t addr;
-  uint64_t data;
-  uint8_t data_size;
-} __attribute__((packed)) rshim_ioctl_msg2;
-
-enum {
-  RSHIM_IOC_READ = _IOWR('R', 0, rshim_ioctl_msg),
-  RSHIM_IOC_WRITE = _IOWR('R', 1, rshim_ioctl_msg),
-  RSHIM_IOC_READ2 = _IOWR('R', 0, rshim_ioctl_msg2),
-  RSHIM_IOC_WRITE2 = _IOWR('R', 1, rshim_ioctl_msg2),
-};
-
 #ifdef __linux__
 static void rshim_fuse_rshim_ioctl(fuse_req_t req, int cmd, void *arg,
                                    struct fuse_file_info *fi,


### PR DESCRIPTION
Syntax:
./rshim --help
  ...
  -c, --cmdmode             run in command line mode
    -r, --reg <addr.[32|64] [value]> set debug mode
  -i, --index               use device path /dev/rshim<i>/
  ...

Example:
  ./rshim -c -i 0 -r 0x13000c48.64
  [0x13000c48] -> 0x0000000000000018

  ./rshim -c -i 0 -r 0x13000c48.64 0x10018
  [0x13000c48] <- 0x0000000000010018

UEFI debugging can be enabled now from PCIe host for any rshim:
  ./rshim -c -i <N> -s 1

RM #4345395