### PR TITLE
bfb-install: don't exit script when rshim install fails

### DIFF
--- a/scripts/bfb-install
+++ b/scripts/bfb-install
@@ -200,7 +200,7 @@ push_boot_stream_via_local_rshim()
 
   if ! $sudo_prefix sh -c "cat ${bfb} ${cfg:+$cfg} ${rootfs:+${rootfs}} ${pv:+| ${pv} | cat -} > ${rshim_node}/boot"; then
     echo "Error: Failed to push boot stream via local rshim"
-    exit 1
+    return
   fi
 
 
@@ -219,7 +219,7 @@ push_boot_stream_via_remote_rshim_scp()
   echo "Pushing bfb${cfg:+ + cfg}${rootfs:+ + rootfs} to ${ip} via scp"
   if ! sh -c "cat ${bfb} ${cfg:+$cfg} ${rootfs:+${rootfs}} ${pv:+| ${pv} | cat -} | ssh root@$ip \"cat > ${rshim_node}/boot\""; then
     echo "Error: Failed to push boot stream via remote rshim with scp"
-    exit 1
+    return
   fi
 }
 


### PR DESCRIPTION
Exiting the script results in rshim log not printed on to the screen missing the reason why the install failed.

Cherry-picked from 522ab3be (RM #4328011)

RM #4346735