### PR TITLE
bfb-install: pack the bf.cfg into the generated BFB

### DIFF
--- a/scripts/bfb-install
+++ b/scripts/bfb-install
@@ -799,7 +799,7 @@ if [ -n "${pldm}" ]; then
     exit 1
   fi
 
-  if ! mlx-mkbfb ${pldm_nicfw:+--nicfw ${pldm_nicfw}} ${pldm_bfb} ${TMP_DIR}/pldm/pldm.bfb; then
+  if ! mlx-mkbfb ${pldm_nicfw:+--nicfw ${pldm_nicfw}} ${cfg:+--boot-args ${cfg}} ${pldm_bfb} ${TMP_DIR}/pldm/pldm.bfb; then
     echo "Error: unable to create bfb from pldm"
     exit 1
   fi

--- a/src/rshim_cmdmode.c
+++ b/src/rshim_cmdmode.c
@@ -249,10 +249,6 @@ static int bfdump(void)
       goto done;
     }
 
-    /* Check completion. */
-    if (sp.dbg_cmd != RSH_DBG_CMD_BFDUMP)
-      break;
-
     /* Read data. */
     rc = rshim_rw(RSHIM_CHANNEL, scratchpad1_addr,
                  &value, RSHIM_REG_SIZE_8B, true);
@@ -285,10 +281,14 @@ static int bfdump(void)
     cur_len += sizeof(uint64_t);
     if (cur_len >= max_len)
       break;
+
+    /* Check completion. */
+    if (sp.dbg_cmd != RSH_DBG_CMD_BFDUMP)
+      break;
   }
 
 done:
-  printf("bfdump completed\n");
+  printf("\nbfdump completed\n");
 
   /* Clear scratchpad6 since it'll be used by NIC_FW reset. */
   value = 0;


### PR DESCRIPTION
Currently BMC username/password is needed to do upgrade in DPU mode. This information is not provided when BFB is generated from PLDM. This commit packs the bf.cfg into the generated BFB for this purpose which is provided with argument '-c bf.cfg'.

This commit also has a change to print 'bfdump completed' in a separate line for bfdump, and adjusts the order of the 'done' check so it won't miss the last data.

RM #4368416