### PR TITLE
Reduce CPU utilization by increasing timer interval

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -31,7 +31,7 @@
 #define RSHIM_MAX_DEV 64
 
 /* RShim timer interval in milliseconds. */
-#define RSHIM_TIMER_INTERVAL 1
+#define RSHIM_TIMER_INTERVAL 10
 
 /* Intervals to check the locked mode. */
 #define RSHIM_CHECK_LOCKED_MODE_MS      100


### PR DESCRIPTION
Increased RSHIM_TIMER_INTERVAL from 1ms to 10ms to reduce CPU utilization when the system is under high load.

This resolves an issue where rshim's CPU utilization would increase (e.g., from 5% to 16%) when BMC CPU utilization increased due to background processes.

RM #4271127