### PR TITLE
bfb-install: Reactivate NIC_FW for runtime upgrade

### DIFF
--- a/scripts/bfb-install
+++ b/scripts/bfb-install
@@ -976,6 +976,16 @@ if [ ${nic_mode} -eq 1 -a -n "${pcie_bd}" -a ${runtime} -eq 0 ]; then
   done
 fi
 
+# Reactivate NIC_FW
+if which flint &> /dev/null; then
+  if [ -n "${pcie_bd}" -a ${runtime} -eq 1 ]; then
+    # Suppress errors if already activated.
+    flint -d ${pcie_bd}.0 ir >&/dev/null
+  fi
+else
+  echo "Flint not found. Skip NIC_FW reactivation."
+fi
+
 push_boot_stream
 
 wait_for_update_to_finish


### PR DESCRIPTION
When NIC_FW is upgraded, it'll be marked as pending and prevents another update before activation. This script reactivates NIC_FW for runtime upgrade to allow multiple updates which is the same behavior as PLDM upgrade from platform BMC..

RM #4403764