### PR TITLE
scripts/bfb-tool: Add flat format support for BFB

### DIFF
--- a/man/bfb-tool.8
+++ b/man/bfb-tool.8
@@ -5,7 +5,8 @@
 bfb-tool - Tool for extracting and repackaging BFBs
 
 .SH SYNOPSIS
-bfb-tool <action> --bfb <BFB> --psid <PSID>|--opn <OPN>|--all [-p|--profile <Profile>] [--output-dir <dir>] [-v|--verbose]
+bfb-tool <action> --bfb <BFB> --psid <PSID>|--opn <OPN>|--all [-p|--profile <Profile>] [-o|--output-dir <dir>] [-f|--output-format <format>] [-B|--output-bfb] [-v|--verbose]
+
 
 .SH DESCRIPTION
 The bfb-tool is used for managing BFBs (bf-bundle/bf-fwbundle). It supports two primary actions: extract and repack.
@@ -47,8 +48,19 @@ Extract or repack for all applicable configurations.
 Specify a configuration profile.
 
 .TP
-.B --output-dir <dir>
+.B -o, --output-dir <dir>
 Specify the directory where results will be stored.
+
+.TP
+.B -f, --output-format <format>
+Specify the output BFB format (bundle, flat). "bundle" format is the format for DPU mode (default).
+"flat" format is the format for NIC mode.
+
+.TP
+.B -B, --output-bfb <bfb>
+Specify output BFB file name.
+The default for bundle format: bf-fwbundle-<version>-prod-<OPN>.bfb
+The default for flat format: bf-fwbundle-<version>-prod-<OPN>.flat.bfb
 
 .TP
 .B -v, --verbose

--- a/scripts/bfb-tool
+++ b/scripts/bfb-tool
@@ -47,15 +47,20 @@ error() {
 
 usage() {
 	cat << EOF
-	Usage: $(basename $0) <action> --bfb <BFB> --psid <PSID>|--opn <OPN>|--all [-p|--profile <Profile>] [--output-dir <dir>] [-v|--verbose]
+	Usage: $(basename $0) <action> --bfb <BFB> --psid <PSID>|--opn <OPN>|--all [-p|--profile <Profile>] [-o|--output-dir <dir>] [-f|--output-format <format>] [-B|--output-bfb] [-v|--verbose]
 
 	action:                 extract or repack. The repack action includes extracting and building a new BFB for a specific OPN/PSID
 
+	Options:
 	--bfb <BFB>             bf-bundle/bf-fwbundle BFB
 	--psid <PSID>           PSID of the DPU to extract the paylod
 	--opn <OPN>             OPN of the DPU to extract the payload
 	--profile <Profile>     Configuration Profile
 	--output-dir <dir>      Directory to keep the results
+	--output-format <format>  Output format (bundle, flat)
+	                        Bundle format is the format for DPU mode (default).
+	                        Flat format is the format for NIC mode.
+	--output-bfb <bfb>      Output BFB name
 	-v|--verbose            Verbose mode
 EOF
 }
@@ -66,6 +71,9 @@ finish() {
 
 MLX_MKBFB=$(which mlx-mkbfb 2> /dev/null)
 BASE_BFB="/usr/lib/firmware/mellanox/boot/default.bfb"
+OUTPUT_FORMAT="bundle"
+OUTPUT_BFB=""
+verbose=0
 
 if [ -z "$1" ]; then
 	usage
@@ -90,54 +98,59 @@ case "$action" in
 		;;
 esac
 
-options=$(getopt -l "output-dir:,psid:,opn:,bfb:,profile:,all,help,verbose" -o "o:p:O:b:p:ahv" -a -- "$@")
+options=$(getopt -l "output-dir:,psid:,opn:,bfb:,profile:,output-format:,output-bfb:,all,help,verbose" -o "o:p:O:b:p:f:B:ahv" -a -- "$@")
 
 eval set -- "$options"
 
 while true
 do
-        case $1 in
-                -h|--help)
-                    usage
-                    exit 0
-                    ;;
-				-a|--all)
-					BUILD_ALL=1
-					;;
-				-b|--bfb)
-					shift
-					bfb=$1
-					;;
-				-p|--profile)
-					shift
-					profile=$1
-					;;
-                -o|--output-dir)
-                    shift
-                    OUTPUT_DIR=$1
-                    ;;
-                -p|--psid)
-                    shift
-					ID_SET="PSID"
-                    BOARD_ID=$1
-                    ;;
-                -O|--opn)
-                    shift
-					ID_SET="OPN"
-                    BOARD_ID=$1
-                    ;;
-                -v|--verbose)
-                    verbose=1
-                    set -xv
-                    ;;
-				-R|--repackage)
-					REPACK=1
-					;;
-                --)
-                    shift
-                    break;;
-        esac
-        shift
+	case $1 in
+		-h|--help)
+			usage
+			exit 0
+			;;
+		-a|--all)
+			BUILD_ALL=1
+			;;
+		-b|--bfb)
+			shift
+			bfb=$1
+			;;
+		-p|--profile)
+			shift
+			profile=$1
+			;;
+		-o|--output-dir)
+			shift
+			OUTPUT_DIR=$1
+			;;
+		-p|--psid)
+			shift
+			ID_SET="PSID"
+			BOARD_ID=$1
+			;;
+		-O|--opn)
+			shift
+			ID_SET="OPN"
+			BOARD_ID=$1
+			;;
+		-v|--verbose)
+			verbose=1
+			set -xv
+			;;
+		-f|--output-format)
+			shift
+			OUTPUT_FORMAT=$1
+			;;
+		-B|--output-bfb)
+			shift
+			OUTPUT_BFB=$1
+			;;
+		--)
+			shift
+			break;;
+	esac
+	shift
 done
 
 BUILD_ALL=${BUILD_ALL:-0}
@@ -170,6 +183,23 @@ if [ -z "$MLX_MKBFB" ]; then
 	error "mlx-mkbfb is required"
 	exit 1
 fi
+
+if ! jq --version > /dev/null 2>&1; then
+	error "jq is required"
+	exit 1
+fi
+
+case "$OUTPUT_FORMAT" in
+	"bundle")
+		;;
+	"flat")
+		;;
+	*)
+		error "Unsupported output format: $OUTPUT_FORMAT"
+		usage
+		exit 1
+		;;
+esac
 
 if [ "`uname -m`" != "aarch64" ]; then
 	if [ ! -x /usr/bin/qemu-aarch64-static ]; then
@@ -342,12 +372,30 @@ create_info()
 # Create JSON using jq
 odata_count=1
 
+if [ "$OUTPUT_FORMAT" == "bundle" ]; then
+	bsp_source="${BSP_CAPSULE##*/}"
+	nic_fw_source="${NIC_FW##*/}"
+	bmc_fw_source="${BMC_FW##*/}"
+	cec_fw_source="${CEC_FW##*/}"
+	dpu_gi_source="${DPU_GI##*/}"
+	nic_fw_gi_source="${NIC_FW_GI##*/}"
+	profile_source="${PROFILE##*/}"
+else
+	bsp_source="dump-capsule-v0"
+	nic_fw_source="dump-nicfw-v0"
+	bmc_fw_source="dump-image-v0"
+	cec_fw_source="dump-upgrade-image-v0"
+	dpu_gi_source="dump-dpu-gi-v0"
+	nic_fw_gi_source="dump-ramdisk-v0"
+	profile_source="dump-cfg-gi-v0"
+fi
+
 json_output=$(jq -n \
 	--arg odata_count "$odata_count" \
 	--arg odata_id "/redfish/v1/UpdateService/SoftwareInventory/$odata_count" \
 	--arg bsp_name "${BFREV}_BSP" \
-	--arg bsp_version "$BSP_VERSION" \
-	--arg bsp_source "${BSP_CAPSULE##*/}" \
+	--arg bsp_version "${BSP_VERSION}" \
+	--arg bsp_source "${bsp_source}" \
 '{
 	"//": "This JSON represents a Redfish Software Inventory collection containing multiple software components.",
 	"@odata.type": "#SoftwareInventoryCollection.SoftwareInventoryCollection",
@@ -372,7 +420,7 @@ if [ -n "$ATF_VERSION" ]; then
 		--arg odata_id "/redfish/v1/UpdateService/SoftwareInventory/$odata_count" \
 		--arg atf_name "${BFREV}_ATF" \
 		--arg atf_version "${ATF_VERSION}" \
-		--arg atf_source "${BSP_CAPSULE##*/}" \
+		--arg atf_source "${bsp_source}" \
 		'.Members += [{
 			"@odata.id": $odata_id,
 			"Id": $odata_count,
@@ -389,7 +437,7 @@ if [ -n "$UEFI_VERSION" ]; then
 		--arg odata_id "/redfish/v1/UpdateService/SoftwareInventory/$odata_count" \
 		--arg uefi_name "${BFREV}_UEFI" \
 		--arg uefi_version "${UEFI_VERSION}" \
-		--arg uefi_source "${BSP_CAPSULE##*/}" \
+		--arg uefi_source "${bsp_source}" \
 		'.Members += [{
 			"@odata.id": $odata_id,
 			"Id": $odata_count,
@@ -406,7 +454,7 @@ if [ -n "$NIC_FW_VERSION" ]; then
 		--arg odata_id "/redfish/v1/UpdateService/SoftwareInventory/$odata_count" \
 		--arg nic_fw_name "${BFREV}_NIC_FW" \
 		--arg nic_fw_version "${NIC_FW_VERSION}" \
-		--arg nic_fw_source "${NIC_FW##*/}" \
+		--arg nic_fw_source "${nic_fw_source}" \
 		'.Members += [{
 			"@odata.id": $odata_id,
 			"Id": $odata_count,
@@ -423,7 +471,7 @@ if [ -n "$BMC_FW_VERSION" ]; then
 		--arg odata_id "/redfish/v1/UpdateService/SoftwareInventory/$odata_count" \
 		--arg bmc_fw_name "${BFREV}_BMC_FW" \
 		--arg bmc_fw_version "${BMC_FW_VERSION}" \
-		--arg bmc_fw_source "${BMC_FW##*/}" \
+		--arg bmc_fw_source "${bmc_fw_source}" \
 		'.Members += [{
 			"@odata.id": $odata_id,
 			"Id": $odata_count,
@@ -440,7 +488,7 @@ if [ -n "$CEC_FW_VERSION" ]; then
 		--arg odata_id "/redfish/v1/UpdateService/SoftwareInventory/$odata_count" \
 		--arg cec_fw_name "${BFREV}_CEC_FW" \
 		--arg cec_fw_version "${CEC_FW_VERSION}" \
-		--arg cec_fw_source "${CEC_FW##*/}" \
+		--arg cec_fw_source "${cec_fw_source}" \
 		'.Members += [{
 			"@odata.id": $odata_id,
 			"Id": $odata_count,
@@ -457,7 +505,7 @@ if [ -n "$DPU_GI_VERSION" ]; then
 		--arg odata_id "/redfish/v1/UpdateService/SoftwareInventory/$odata_count" \
 		--arg dpu_gi_name "${BFREV}_DPU_GI" \
 		--arg dpu_gi_version "${DPU_GI_VERSION}" \
-		--arg dpu_gi_source "${DPU_GI##*/}" \
+		--arg dpu_gi_source "${dpu_gi_source}" \
 		'.Members += [{
 			"@odata.id": $odata_id,
 			"Id": $odata_count,
@@ -474,7 +522,7 @@ if [ -n "$NIC_FW_GI_VERSION" ]; then
 		--arg odata_id "/redfish/v1/UpdateService/SoftwareInventory/$odata_count" \
 		--arg nic_fw_gi_name "${BFREV}_NIC_FW_GI" \
 		--arg nic_fw_gi_version "${NIC_FW_GI_VERSION}" \
-		--arg nic_fw_gi_source "${NIC_FW_GI##*/}" \
+		--arg nic_fw_gi_source "${nic_fw_gi_source}" \
 		'.Members += [{
 			"@odata.id": $odata_id,
 			"Id": $odata_count,
@@ -491,7 +539,7 @@ if [ -n "$profile" ]; then
 		--arg odata_id "/redfish/v1/UpdateService/SoftwareInventory/$odata_count" \
 		--arg profile_name "$PROFILE_NAME" \
 		--arg profile_version "$PROFILE_VERSION" \
-		--arg profile_source "${PROFILE##*/}" \
+		--arg profile_source "${profile_source}" \
 		'.Members += [{
 			"@odata.id": $odata_id,
 			"Id": $odata_count,
@@ -504,8 +552,9 @@ fi
 echo "$json_output" > ${TARGET_DIR}/info.json
 }
 
-rebuild_bfb()
+rebuild_bfb_bundle()
 {
+	info "Rebuilding BFB in bundle format"
 	cd $INITRAMFS_REPKG_DIR
 
 	# Remove the extra payload
@@ -531,14 +580,41 @@ rebuild_bfb()
 	fi
 
 	find . | cpio -H newc -o | gzip -9 > ../dump-initramfs-v0
-	target_bfb=${bfb##*/}
-	target_bfb=${target_bfb/.bfb/-${OPN}.bfb}
-
-	create_info
 
 	$MLX_MKBFB --initramfs ../dump-initramfs-v0 --info ${TARGET_DIR}/info.json ${bfb} ${TARGET_DIR}/${target_bfb}
 
 	cp /usr/bin/qemu-aarch64-static ./usr/bin
+}
+
+rebuild_bfb_flat()
+{
+	info "Rebuilding BFB in flat format"
+	cd $INITRAMFS_REPKG_DIR
+	MKBFB_PARAMS="--info ${TARGET_DIR}/info.json \
+		--capsule ${TARGET_DIR}/${BSP_CAPSULE##*/} \
+		--image ${TARGET_DIR}/${BMC_FW##*/} \
+		--upgrade-image ${TARGET_DIR}/${CEC_FW##*/} \
+		--nicfw ${TARGET_DIR}/${NIC_FW##*/}"
+
+	if [ -f "${TARGET_DIR}/${DPU_GI##*/}" ]; then
+		MKBFB_PARAMS="${MKBFB_PARAMS} \
+		--dpu-gi ${TARGET_DIR}/${DPU_GI##*/}"
+	fi
+
+	if [ -f "${TARGET_DIR}/${NIC_FW_GI##*/}" ]; then
+		MKBFB_PARAMS="${MKBFB_PARAMS} \
+		--ramdisk ${TARGET_DIR}/${NIC_FW_GI##*/}"
+	fi
+
+	if [ -f "${TARGET_DIR}/${PROFILE##*/}" ]; then
+		MKBFB_PARAMS="${MKBFB_PARAMS} \
+		--cfg-gi ${TARGET_DIR}/${PROFILE##*/}"
+	fi
+
+	$MLX_MKBFB \
+		${MKBFB_PARAMS} \
+		./${BASE_BFB} \
+		${TARGET_DIR}/${target_bfb}
 }
 
 handle_opn()
@@ -652,12 +728,30 @@ handle_opn()
 	fi
 
 	if [ $REPACK -eq 1 ]; then
-		rebuild_bfb
+		if [ -n "$OUTPUT_BFB" ]; then
+			target_bfb=${OUTPUT_BFB}
+		else
+			target_bfb=${bfb##*/}
+			if [ "$OUTPUT_FORMAT" == "bundle" ]; then
+				target_bfb=${target_bfb/.bfb/-${OPN}.bfb}
+			else
+				target_bfb=${target_bfb/.bfb/-${OPN}.flat.bfb}
+			fi
+		fi
+
+		create_info
+		if [ "$OUTPUT_FORMAT" == "bundle" ]; then
+			rebuild_bfb_bundle
+		else
+			rebuild_bfb_flat
+		fi
 	fi
 }
 
 if [ $REPACK -eq 1 ]; then
-	cleanup_base_initramfs
+	if [ "$OUTPUT_FORMAT" == "bundle" ]; then
+		cleanup_base_initramfs
+	fi
 fi
 
 total_ids=0
@@ -674,7 +768,9 @@ do
 		PSID=$2
 		NIC_FW_VERSION=$3
 		if [ -z "$OPN" ]; then
-			echo "WARN: No data found for ${ID_SET}: ${BOARD_ID} in $fwmanager"
+			if [ $verbose -eq 1 ]; then
+				echo "No data found for ${ID_SET}: ${BOARD_ID} in $fwmanager"
+			fi
 			continue
 		fi
 		echo "Found PSID $PSID OPN $OPN FW version $NIC_FW_VERSION in $fwmanager"
@@ -697,12 +793,16 @@ if [ $total_ids -eq 0 ]; then
 	exit 1
 fi
 
-if [ $BUILD_ALL -eq 0 ]; then
-	echo "See the result under ${TARGET_DIR}"
+if [ $REPACK -eq 1 ]; then
+	echo "BFB: ${TARGET_DIR}/$target_bfb"
 else
-	echo "See the result under $(readlink -f ${TARGET_DIR}/..)"
-fi
+	if [ $BUILD_ALL -eq 0 ]; then
+		echo "See the result under ${TARGET_DIR}"
+	else
+		echo "See the result under $(readlink -f ${TARGET_DIR}/..)"
+	fi
 
-du -ach $(find ${TARGET_DIR})
+	du -ach $(find ${TARGET_DIR})
+fi
 
 exit 0


### PR DESCRIPTION
- Added '--output-format flat' option to create bf-fwbundle BFBs in flat format.
- Enables support for DPU in NIC mode.