### PR TITLE
Reduce CPU usage by polling optimization

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -2903,7 +2903,7 @@ int rshim_init(int *epollfd, int *timerfd)
   }
   rshim_set_timer(timer_fd, RSHIM_TIMER_INTERVAL);
   event.data.fd = timer_fd;
-  event.events = EPOLLIN | EPOLLOUT;
+  event.events = EPOLLIN;
   rc = epoll_ctl(epoll_fd, EPOLL_CTL_ADD, timer_fd, &event);
   if (rc == -1) {
     RSHIM_ERR("epoll_ctl failed\n");


### PR DESCRIPTION
Registering EPOLLOUT on timerfd causes epoll_wait() to return immediately since timerfds are always writable. This leads to a busy loop with high syscall frequency and high CPU usage in some cases.

Removing EPOLLOUT allows epoll_wait() to block properly until timer expiration. Verified on BlueField-3: under a certain stress test, CPU usage dropped from 35% to 3%.

RM #[4271227](https://redmine.mellanox.com/issues/4271227)