### PR TITLE
Fix bfdump doesn't return error code in case of success

### DIFF
--- a/src/rshim_cmdmode.c
+++ b/src/rshim_cmdmode.c
@@ -280,6 +280,7 @@ static int bfdump(void)
       printf("Failed to write: %m\n");
       goto done;
     }
+    rc = 0;
     cur_len += sizeof(uint64_t);
     if (cur_len >= max_len)
       break;


### PR DESCRIPTION
When bfdump succeeds, the return value is 8. It's the result value of write sizeof(uint64_t). This fix sets the return value to 0 after the write is successful.