### PR TITLE
Set is_uek64k flag at build time

### DIFF
--- a/rshim.spec.in
+++ b/rshim.spec.in
@@ -16,7 +16,21 @@ BuildRequires: gcc, autoconf, automake, pkgconfig, make
 BuildRequires: pkgconfig(libpci), pkgconfig(libusb-1.0)
 
 %if (0%{?oraclelinux} >= 9)
+%define is_uek64k 0
+%{lua:
+  local handle = io.popen("uname -r")
+  local kernelver = handle:read("*l")
+  handle:close()
+
+  if kernelver and kernelver:match("64k") then
+    rpm.define("is_uek64k 1")
+  end
+}
+%if (0%{?is_uek64k} == 1)
+Requires: kernel-uek64k-core
+%else
 Requires: kernel-uek-core
+%endif
 %else
 %if (0%{?rhel} >= 8 || 0%{?fedora} > 0) && "0%{?ctyunos}" == "0"
 Requires: kernel-modules-extra


### PR DESCRIPTION
This commit detects uek64k at build time and sets the is_uek64k flag, so correct dependencies can be used when installing the binary RPM.

RM #4542951