### PR TITLE
Update version to 2.5.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Copyright (C) 2019 Mellanox Technologies. All Rights Reserved.
 #
 
-AC_INIT([rshim], [2.4.4])
+AC_INIT([rshim], [2.5.1])
 AC_CONFIG_AUX_DIR(config)
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AC_LANG(C)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+rshim (2.5.1) UNRELEASED; urgency=low
+
+  * Improve GitHub CI robustness for ARM builds
+  * Fix rshim drop mode driver binding
+  * bfb-tool: Added qemu-aarch64-static installation guidance
+  * bfb-tool: Added workaround for mlx_fwsfx_gen
+
+ -- Penghe Geng <pgeng@nvidia.com>  Wed, 20 Aug 2025 11:32:41 -0400
+
 rshim (2.4.4) UNRELEASED; urgency=low
 
   * Added support for bf-fwbundle per OPN

--- a/rhel/rshim.spec.in
+++ b/rhel/rshim.spec.in
@@ -65,6 +65,12 @@ via the virtual console or network interface.
 %{_mandir}/man8/bf-pldm-ver.8.gz
 
 %changelog
+* Wed Aug 20 2025 Penghe Geng <pgeng@nvidia.com> - 2.5.1
+- Improve GitHub CI robustness for ARM builds
+- Fix rshim drop mode driver binding
+- bfb-tool: Added qemu-aarch64-static installation guidance
+- bfb-tool: Added workaround for mlx_fwsfx_gen
+
 * Tue Jul 22 2025 Penghe Geng <pgeng@nvidia.com> - 2.4.4
 - Added support for bf-fwbundle per OPN
 - Set is_uek64k flag at build time

--- a/rshim.spec.in
+++ b/rshim.spec.in
@@ -164,6 +164,12 @@ fi
 %{_datadir}/selinux/packages/rshim-fix.te
 
 %changelog
+* Wed Aug 20 2025 Penghe Geng <pgeng@nvidia.com> - 2.5.1
+- Improve GitHub CI robustness for ARM builds
+- Fix rshim drop mode driver binding
+- bfb-tool: Added qemu-aarch64-static installation guidance
+- bfb-tool: Added workaround for mlx_fwsfx_gen
+
 * Tue Jul 22 2025 Penghe Geng <pgeng@nvidia.com> - 2.4.4
 - Added support for bf-fwbundle per OPN
 - Set is_uek64k flag at build time


### PR DESCRIPTION
## Summary
- Bump rshim version from 2.4.4 to 2.5.1
- Update changelog with recent commits since 2.4.4

## Changes included in this release
- Improve GitHub CI robustness for ARM builds
- Fix rshim drop mode driver binding
- bfb-tool: Added qemu-aarch64-static installation guidance
- bfb-tool: Added workaround for mlx_fwsfx_gen