### PR TITLE
Fix SIGTERM segfault when rshim exits

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -3059,9 +3059,12 @@ static void rshim_main(int argc, char *argv[])
     }
   }
 
-  if (!strcmp(rshim_backend_name, "pcie-lf") ||
-      !strcmp(rshim_backend_name, "pcie")) {
-    rshim_pcie_exit();
+  for (i = 0; i < RSHIM_MAX_DEV; i++) {
+    bd = rshim_devs[i];
+    if (bd && bd->type == RSH_BACKEND_PCIE) {
+      rshim_pcie_exit();
+      break;
+    }
   }
 
   rshim_stop();


### PR DESCRIPTION
When SIGTERM is sent to rshim process, a segfault could occur if rshim_backend_name is NULL. This happens when no specific backend is specified via command line (-b flag), which is the common auto-detect mode.

This fix checks the actual backend types of registered devices instead of rshim_backend_name.

Fixes: 6e4ed8290e1f ("Deregister driver (vfio or uio) when not in use")

RM #[4654756](https://redmine.mellanox.com/issues/4654756)