### PR TITLE
linux: fix console handling

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -191,7 +191,11 @@ const char *magic_to_str(uint64_t magic)
 
 /* Terminal characteristics for newly created consoles. */
 #define INIT_C_CC "\003\034\177\025\004\0\1\0\021\023\032\0\022\017\027\026\0"
+#ifdef __linux__
+static struct termios2 init_console_termios = {
+#else
 static struct termios init_console_termios = {
+#endif
   .c_iflag = INLCR | ICRNL,
   .c_oflag = OPOST | ONLCR,
   .c_cflag = B115200 | HUPCL | CLOCAL | CREAD | CS8,

--- a/src/rshim.h
+++ b/src/rshim.h
@@ -16,7 +16,9 @@
 #include <fcntl.h>
 #ifdef __linux__
 #include <linux/virtio_ids.h>
+#include <asm/termios.h>
 #else
+#include <termios.h>
 #define	VIRTIO_ID_NET 1
 #define	VIRTIO_ID_CONSOLE 3
 #endif
@@ -26,7 +28,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mount.h>
-#include <termios.h>
 #include <unistd.h>
 #ifdef HAVE_CONFIG_H
 #include <config.h>
@@ -408,7 +409,11 @@ struct rshim_backend {
   pthread_cond_t ctrl_wait_cond;
 
   /* Current termios settings for the console. */
+#ifdef __linux__
+  struct termios2 cons_termios;
+#else
   struct termios cons_termios;
+#endif
 
   /* Pending boot & fifo request for the worker. */
   uint8_t *boot_work_buf;


### PR DESCRIPTION
Since using glibc 2.42 struct termio was no longer exposed from glibc.

An earlier fix was to provide the definition of struct termio if not given in glibc. But it mixed up the ioctls for struct termios with an internal struct termio.

This commit fixes this by providing definitions from kernel headers instead of glibc and translating between all relevant ioctl sets necessary to use screen, minicom or stty with different glibc versions.