### PR TITLE
bfb-tool: preserve original filename in repack for --all/--opn modes

### DIFF
--- a/scripts/bfb-tool
+++ b/scripts/bfb-tool
@@ -1041,10 +1041,14 @@ handle_opn()
 			target_bfb=${OUTPUT_BFB}
 		else
 			target_bfb=${bfb##*/}
-			if [ "$OUTPUT_FORMAT" == "bundle" ]; then
+			# Append OPN to filename only when the directory uses PSID,
+			# since the OPN is not captured in the directory path.
+			# In --all/--opn modes the OPN is already in the directory.
+			if [ $BUILD_ALL -eq 0 ] && [ "$ID_SET" == "PSID" ]; then
 				target_bfb=${target_bfb/.bfb/-${OPN}.bfb}
-			else
-				target_bfb=${target_bfb/.bfb/-${OPN}.flat.bfb}
+			fi
+			if [ "$OUTPUT_FORMAT" != "bundle" ]; then
+				target_bfb=${target_bfb/.bfb/.flat.bfb}
 			fi
 		fi
 


### PR DESCRIPTION
## Summary

`bfb-tool repack` unconditionally appends the OPN to the output BFB filename, even when the OPN is already present in the output directory path. This results in redundant filenames.

Only append OPN to the filename in `--psid` mode, where the directory uses the PSID and the OPN provides additional identification. In `--all` and `--opn` modes, the OPN is already captured in the directory path.

## Before

```
$ bfb-tool repack --bfb bf-fwbundle-2.9.4-36-900-9D3B6-F2SC-EA0_25.12_prod.bfb --all --output-dir /tmp/test/

BFB: /tmp/test/bf-fwbundle-2.9.4-36-900-9D3B6-F2SC-EA0_25.12_prod/900-9D3B6-F2SC-EA0_Ax/bf-fwbundle-2.9.4-36-900-9D3B6-F2SC-EA0_25.12_prod-900-9D3B6-F2SC-EA0_Ax.bfb
```

## After

```
$ bfb-tool repack --bfb bf-fwbundle-2.9.4-36-900-9D3B6-F2SC-EA0_25.12_prod.bfb --all --output-dir /tmp/test/

BFB: /tmp/test/bf-fwbundle-2.9.4-36-900-9D3B6-F2SC-EA0_25.12_prod/900-9D3B6-F2SC-EA0_Ax/bf-fwbundle-2.9.4-36-900-9D3B6-F2SC-EA0_25.12_prod.bfb
```

Fixes: RM #4813259
