### PR TITLE
bfb-tool: preserve original filename in repack for --all/--opn modes …

### DIFF
--- a/scripts/bfb-tool
+++ b/scripts/bfb-tool
@@ -1058,10 +1058,14 @@ handle_opn()
 			target_bfb=${OUTPUT_BFB}
 		else
 			target_bfb=${bfb##*/}
-			if [ "$OUTPUT_FORMAT" == "bundle" ]; then
+			# Append OPN to filename only when the directory uses PSID,
+			# since the OPN is not captured in the directory path.
+			# In --all/--opn modes the OPN is already in the directory.
+			if [ $BUILD_ALL -eq 0 ] && [ "$ID_SET" == "PSID" ]; then
 				target_bfb=${target_bfb/.bfb/-${OPN}.bfb}
-			else
-				target_bfb=${target_bfb/.bfb/-${OPN}.flat.bfb}
+			fi
+			if [ "$OUTPUT_FORMAT" != "bundle" ]; then
+				target_bfb=${target_bfb/.bfb/.flat.bfb}
 			fi
 		fi
 


### PR DESCRIPTION
The OPN was unconditionally appended to the output filename, even when it was already present in the output directory path. This caused redundant filenames like name-OPN.bfb inside a directory named OPN/.

Only append OPN to the filename in --psid mode, where the directory uses the PSID and the OPN provides additional identification.

Cherry-pick @Maorazr work

Fixes: RM #4813259