### PR TITLE
Software shadow ring for the DPU log scratch buffer

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -236,6 +236,21 @@ int rshim_pcie_intr_poll_interval = 10;  /* Interrupt polling in milliseconds */
 bool rshim_force_mode;                   /* Keep /dev/rshim<N> & send a force cmd */
 bool rshim_cmdmode;                      /* Command mode */
 
+/*
+ * Per-backend DPU log shadow ring capacity, in bytes.  The shadow ring
+ * is a software-side circular buffer that mirrors the DPU's 1 KiB hw
+ * scratch ring, so multiple concurrent misc readers (bfb-install +
+ * watch + redfish) can all see the same log content without racing
+ * each other for a destructive hw read.  Set to 0 to disable.
+ *
+ * Default 65536 ≈ ~1k log lines, plenty for a full bfb install
+ * transcript while costing ~64 KiB per attached rshim.  Override with
+ * a whitespace-separated "LOG_SHADOW_SIZE <bytes>" line in rshim.conf
+ * (same format as all other keys -- no '=' sign, the parser uses
+ * sscanf "%31s%63s").  Set <bytes> to 0 to disable the shadow.
+ */
+int rshim_log_shadow_size = 65536;
+
 /* Array of devices and device names. */
 rshim_backend_t *rshim_devs[RSHIM_MAX_DEV];
 char *rshim_dev_names[RSHIM_MAX_DEV];
@@ -802,6 +817,19 @@ int rshim_boot_open(rshim_backend_t *bd)
   }
 
   bd->is_boot_open = 1;
+
+  /*
+   * A new bfb is being pushed: discard any previously-captured DPU log
+   * lines.  Without this the user sees the pre-install boot session
+   * appended in front of the rshim-boot session that bfb-install is
+   * about to trigger -- two genuine boots, but visually indistinguishable
+   * since both replay the same BL1/BL2 prologue.  Drop the old context
+   * here so the shadow only contains content from this install onward.
+   * The drainer is gated off via is_boot_open/is_booting from this point
+   * until the DPU comes back, so nothing new will land in the shadow
+   * until the rshim boot has actually started logging.
+   */
+  rshim_log_shadow_reset(bd);
 
   /*
    * Disable the watchdog. The channel and offset are the same on all
@@ -1861,6 +1889,15 @@ static void rshim_work_handler(rshim_backend_t *bd)
     rshim_handle_ownership_transfer(bd);
   }
 
+  /*
+   * Drain the DPU log scratch ring into the per-backend shadow ring on
+   * a slow polling cadence (RSHIM_LOG_SHADOW_DRAIN_MS).  Cheap no-op
+   * when the shadow is disabled or the cadence hasn't elapsed.  Runs
+   * here so the daemon keeps the hw ring from saturating even when
+   * nothing is reading from /dev/rshim<N>/misc.
+   */
+  rshim_log_shadow_tick(bd, rshim_timer_ticks);
+
   pthread_mutex_unlock(&bd->mutex);
 }
 
@@ -2734,6 +2771,16 @@ int rshim_register(rshim_backend_t *bd)
   bd->boot_timeout = rshim_boot_timeout;
   bd->display_level = rshim_display_level;
 
+  /* Allocate the DPU log shadow ring (best-effort: a failure here just
+   * disables the shadow for this backend, the legacy direct-ring read
+   * path still works). */
+  if (rshim_log_shadow_size > 0) {
+    rc = rshim_log_shadow_init(bd, (size_t)rshim_log_shadow_size);
+    if (rc)
+      RSHIM_INFO("rshim%d log shadow alloc failed (%d), running without it\n",
+                 bd->index, rc);
+  }
+
   /* Start the keepalive timer. */
   bd->last_keepalive = rshim_timer_ticks;
   bd->timer = rshim_timer_ticks + 1;
@@ -2779,6 +2826,8 @@ void rshim_deregister(rshim_backend_t *bd)
   bd->write_buf = NULL;
 
   rshim_fifo_free(bd);
+
+  rshim_log_shadow_free(bd);
 
   rshim_devs[bd->index] = NULL;
 
@@ -3233,6 +3282,16 @@ static int rshim_load_cfg(void)
       continue;
     } else if (!strcmp(key, "PCIE_HAS_UIO")) {
       rshim_pcie_enable_uio = atoi(value);
+      continue;
+    } else if (!strcmp(key, "LOG_SHADOW_SIZE")) {
+      /* 0 disables the shadow ring; otherwise capped to a sane upper
+       * bound (1 MiB) to keep a misconfig from runaway-allocating. */
+      int sz = atoi(value);
+      if (sz < 0)
+        sz = 0;
+      if (sz > (1 << 20))
+        sz = (1 << 20);
+      rshim_log_shadow_size = sz;
       continue;
     }
 

--- a/src/rshim.h
+++ b/src/rshim.h
@@ -473,6 +473,22 @@ struct rshim_backend {
 
   /* Platform specific register addresses */
   const struct rshim_regs *regs;
+
+  /*
+   * DPU log shadow ring.  When non-NULL the rshim worker periodically
+   * drains the 128-word hw scratch ring into this larger software
+   * buffer, so concurrent misc readers (bfb-install + user's watch +
+   * redfish probes) all see the same content without racing each other
+   * for a destructive read of the live ring.  Allocated in
+   * rshim_register() if rshim_log_shadow_size > 0.
+   *
+   * Placed at the end of the struct on purpose: keeps offsets of all
+   * preceding fields (notably the backend function pointers like
+   * read_rshim / write_rshim) stable, so a partial rebuild that misses
+   * a backend translation unit can't silently corrupt those pointers
+   * via offset drift.
+   */
+  struct rshim_log_shadow *log_shadow;
 };
 
 #define RSHIM_REG_SIZE_4B 4
@@ -623,6 +639,139 @@ int rshim_fifo_fsync(rshim_backend_t *bd, int chan);
 
 /* Display the rshim logging buffer. */
 int rshim_log_show(rshim_backend_t *bd, char *buf, int len);
+
+/*
+ * Drain (reset) the DPU log scratch ring without formatting any text.
+ * Used by misc readers that don't render the log themselves but still
+ * need to prevent the 7-bit scratch_buf_ctl IDX from saturating when
+ * clear_on_read is set.  Returns 0 on success, a negative errno on
+ * failure (semaphore wedged or rshim access error).
+ */
+int rshim_log_drain(rshim_backend_t *bd);
+
+/*
+ * Append a host-side message to the DPU log scratch ring so it shows up
+ * alongside the DPU's own entries on a "cat /dev/rshim0/misc" at
+ * DISPLAY_LEVEL 2.  Use to record rshim-daemon events in the same log
+ * stream the user is already watching (e.g. boot stream open/close,
+ * CLEAR_ON_READ transitions, locked-mode events).
+ *
+ * @module is an index into rshim_log_mod[] (0 = "MISC" is the usual
+ *         choice for host-originated messages).
+ * @level  is an index into rshim_log_levels[] (0 = "INFO", 1 = "WARN",
+ *         2 = "ERR", 3 = "ASSERT").
+ * @msg    is a NUL-terminated plain string with no printf-style
+ *         formatting.  Caller may snprintf into a local buffer first.
+ *
+ * Returns 0 on success, -EINVAL on bad arguments, -EIO on rshim access
+ * failure, -EBUSY if the cross-side semaphore is wedged > 3 seconds, or
+ * -ENOSPC if the ring is already saturated.  If the ring has room for
+ * the header but not the full payload, the message body is truncated
+ * to fit and 0 is returned -- mirroring the legacy mlx-bootctl driver.
+ */
+int rshim_log_write(rshim_backend_t *bd, int module, int level,
+                    const char *msg);
+
+/*
+ * DPU log shadow ring.  Producer is the rshim worker (drainer hook),
+ * consumer is rshim_fuse_misc_read() at DISPLAY_LEVEL 2.  Both run
+ * under bd->mutex, so no internal locking is required.
+ *
+ *   buf      : circular byte buffer of pre-formatted " INFO[MOD]: msg\n"
+ *              lines.
+ *   cap      : power-of-2 capacity in bytes.  0 means "shadow disabled,
+ *              fall back to direct hw-ring reads".
+ *   head     : producer cursor (monotonically increasing; wrap via
+ *              head & (cap - 1)).
+ *   tail     : consumer cursor.  Advanced only when CLEAR_ON_READ is
+ *              set on the misc read; otherwise the shadow is a
+ *              non-destructive cumulative view.
+ *   dropped_bytes : monotonic counter, surfaced as LOG_DROPPED in
+ *              the misc summary when > 0.
+ *   next_drain_tick : gates the polling cadence in the worker.
+ */
+struct rshim_log_shadow {
+  char    *buf;
+  size_t   cap;
+  size_t   head;
+  size_t   tail;
+  uint64_t dropped_bytes;
+  int      next_drain_tick;
+};
+
+/*
+ * Allocate / free the shadow ring on a backend.  rshim_log_shadow_init()
+ * may be called with cap == 0 to mean "disabled"; rshim_log_shadow_free()
+ * is safe to call on an already-NULL bd->log_shadow.
+ */
+int  rshim_log_shadow_init(rshim_backend_t *bd, size_t cap);
+void rshim_log_shadow_free(rshim_backend_t *bd);
+
+/*
+ * Discard all pending shadow content (head/tail back to 0, dropped
+ * counter zeroed) without releasing the backing buffer.  Used by the
+ * boot-open path so a new bfb install sees a clean log instead of
+ * inheriting the pre-install boot session.  Safe to call on a backend
+ * with no shadow.  Must be called with bd->mutex held.
+ */
+void rshim_log_shadow_reset(rshim_backend_t *bd);
+
+/*
+ * Drainer hook -- run from the rshim worker every
+ * RSHIM_LOG_SHADOW_DRAIN_MS milliseconds.  Acquires the cross-side
+ * semaphore, pulls anything in the hw scratch ring into the shadow,
+ * and releases.  Cheap no-op when the shadow is disabled, the rshim
+ * is not accessible, or the cadence has not yet elapsed.  Must be
+ * called with bd->mutex held.
+ *
+ * @now_ticks is the caller's view of the millisecond tick counter
+ * (rshim_timer_ticks in the daemon); used for rate-limiting without
+ * exposing the daemon's internal clock to the log subsystem.
+ */
+void rshim_log_shadow_tick(rshim_backend_t *bd, int now_ticks);
+
+/*
+ * Force-drain the hw scratch ring into the shadow right now,
+ * bypassing the cadence rate-limit applied by rshim_log_shadow_tick().
+ * Intended for callers that have just written to the hw ring at high
+ * rate (e.g. the LOG_MSG handler hitting -ENOSPC) and want to make
+ * room for an immediate retry.
+ *
+ * Returns the number of bytes appended to the shadow (>= 0); 0 means
+ * "nothing was waiting in the ring" or "shadow disabled / rshim not
+ * accessible".  Must be called with bd->mutex held.
+ */
+int rshim_log_shadow_flush(rshim_backend_t *bd);
+
+/*
+ * Format @msg as " LEVEL[MOD]: msg\n" (matching the wire format the
+ * drainer produces for DPU-originated entries) and append it directly
+ * to the shadow ring, bypassing the hw scratch ring entirely.
+ *
+ * Used by host-side log injectors (LOG_MSG) so they don't have to
+ * round-trip through the DPU's 1 KiB / 7-bit outbound ring, which
+ * saturates at ~21 messages and trips spurious -ENOSPC under shell-
+ * driven bursts.  The shadow itself is ~64 KiB and won't bottleneck
+ * at realistic LOG_MSG rates.
+ *
+ * Returns 0 on success or -EINVAL on bad arguments / shadow disabled.
+ * Must be called with bd->mutex held.
+ */
+int rshim_log_shadow_msg(rshim_backend_t *bd, int module, int level,
+                         const char *msg);
+
+/*
+ * Render the shadow into @out (up to @max bytes), emitting the same
+ * "--- Log Messages ---" banner that rshim_log_show() produces so
+ * the misc output format is unchanged.  If bd->clear_on_read is set,
+ * advances tail to head as a side-effect (destructive read); otherwise
+ * the shadow contents are preserved for subsequent readers.  Must be
+ * called with bd->mutex held.  Returns bytes written.
+ */
+int  rshim_log_shadow_render(rshim_backend_t *bd, char *out, int max);
+
+/* Configured default capacity of bd->log_shadow.buf (bytes). */
+extern int rshim_log_shadow_size;
 
 bool rshim_allow_device(const char *devname);
 

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -823,10 +823,49 @@ static int rshim_fuse_misc_read(struct cuse_dev *cdev, int fflags,
     n = snprintf(p, len, "%-16s%d (0:no, 1:yes)\n", "CLEAR_ON_READ",
                  bd->clear_on_read);
     p += n;
+    len -= n;
+
+    /* Surface the shadow-ring state so users can tell at a glance how
+     * much DPU log history is cached and whether anything has rolled
+     * off the back of the buffer. */
+    if (bd->log_shadow) {
+      n = snprintf(p, len, "%-16s%zu/%zu bytes\n", "LOG_SHADOW",
+                   bd->log_shadow->head - bd->log_shadow->tail,
+                   bd->log_shadow->cap);
+      p += n;
+      len -= n;
+
+      n = snprintf(p, len, "%-16s%llu bytes\n", "LOG_DROPPED",
+                   (unsigned long long)bd->log_shadow->dropped_bytes);
+      p += n;
+      len -= n;
+    }
   } else if (bd->display_level == 2) {
-    n = rshim_log_show(bd, p, len);
+    /* Prefer the shadow ring when it's available: cumulative across
+     * readers, decoupled from the 128-word hw limit, and renders the
+     * same banner + body format as rshim_log_show(). */
+    if (bd->log_shadow)
+      n = rshim_log_shadow_render(bd, p, len);
+    else
+      n = rshim_log_show(bd, p, len);
     p += n;
   }
+
+  /*
+   * Legacy hw-ring drain on misc read, only when the shadow is NOT
+   * active.  With the shadow active the per-backend worker keeps the
+   * hw ring trimmed on a 500 ms cadence (see rshim_log_shadow_tick),
+   * so an additional drain here would just add a semaphore round-trip
+   * for no observable benefit.
+   *
+   * Without the shadow this is the only path that resets the 7-bit
+   * IDX at display_level 0 and 1 -- bfb-install's reset_bmc_rshim_log()
+   * relies on it because the BMC's rshim runs at DISPLAY_LEVEL 0 by
+   * default and the script only flips CLEAR_ON_READ around a plain
+   * "cat /dev/rshim0/misc".
+   */
+  if (bd->clear_on_read && !bd->log_shadow)
+    (void)rshim_log_drain(bd);
 
   rm->len = p - rm->buffer;
 
@@ -927,6 +966,87 @@ static int rshim_fuse_misc_write(struct cuse_dev *cdev, int fflags,
     if (sscanf(p, "%d", &value) != 1)
       goto invalid;
     bd->clear_on_read = !!value;
+  } else if (strcmp(key, "LOG_MSG") == 0) {
+    /*
+     * Append a host-side message to the DPU log scratch ring so it
+     * shows up at DISPLAY_LEVEL 2 alongside the DPU's own entries.
+     *
+     * Accepted forms (the level keyword is optional and case-sensitive,
+     * matching rshim_log_levels[]):
+     *
+     *   echo "LOG_MSG INFO Hello world"   > /dev/rshim0/misc
+     *   echo "LOG_MSG WARN something"     > /dev/rshim0/misc
+     *   echo "LOG_MSG ERR  oh no"         > /dev/rshim0/misc
+     *   echo "LOG_MSG plain text"         > /dev/rshim0/misc   (defaults to INFO)
+     *
+     * Module is always MISC (index 0) so the entry renders as
+     * " INFO[MISC]: <text>", which is what shell-driven diagnostics and
+     * scripted reproducers (e.g. saturating the 7-bit IDX) actually
+     * want.  Callers needing a different module should use the C-level
+     * rshim_log_write() API directly.
+     */
+    {
+      static const char *const log_level_kw[] = {
+          "INFO", "WARN", "ERR", "ASSERT"
+      };
+      int log_level = 0;
+      const char *msg = p;
+      size_t kw_len;
+      unsigned int k;
+
+      while (*msg == ' ' || *msg == '\t')
+        msg++;
+
+      for (k = 0; k < sizeof(log_level_kw) / sizeof(log_level_kw[0]); k++) {
+        kw_len = strlen(log_level_kw[k]);
+        if (!strncmp(msg, log_level_kw[k], kw_len) &&
+            (msg[kw_len] == ' ' || msg[kw_len] == '\t')) {
+          log_level = (int)k;
+          msg += kw_len;
+          while (*msg == ' ' || *msg == '\t')
+            msg++;
+          break;
+        }
+      }
+
+      if (*msg == '\0' || *msg == '\n')
+        goto invalid;
+
+      {
+        /* Strip a single trailing newline so "echo" doesn't pad the entry. */
+        char line[256];
+        size_t n = strlen(msg);
+        if (n >= sizeof(line))
+          n = sizeof(line) - 1;
+        memcpy(line, msg, n);
+        line[n] = '\0';
+        if (n > 0 && line[n - 1] == '\n')
+          line[n - 1] = '\0';
+
+        pthread_mutex_lock(&bd->mutex);
+        /*
+         * Shadow active (the default): bypass the hw scratch ring and
+         * append directly to the shadow.  This avoids the 7-bit IDX
+         * cliff that limits the hw ring to ~21 of these messages, and
+         * removes the cross-side semaphore round-trip per LOG_MSG --
+         * relevant when a shell `for` loop hammers the misc node.
+         *
+         * Shadow disabled: fall back to the legacy path that writes
+         * into the hw ring.  This preserves any setup that relies on
+         * LOG_MSG entries showing up in the live ring itself (e.g.
+         * for direct register inspection).
+         */
+        if (bd->log_shadow)
+          rc = rshim_log_shadow_msg(bd, 0 /* MISC */, log_level, line);
+        else
+          rc = rshim_log_write(bd, 0 /* MISC */, log_level, line);
+        pthread_mutex_unlock(&bd->mutex);
+
+        if (rc && rc != -ENOSPC)
+          goto invalid;
+        rc = 0;
+      }
+    }
   } else if (strcmp(key, "BOOT_MODE") == 0) {
     if (sscanf(p, "%x", &value) != 1)
       goto invalid;

--- a/src/rshim_log.c
+++ b/src/rshim_log.c
@@ -290,22 +290,25 @@ static int rshim_log_show_msg(rshim_backend_t *bd, uint64_t hdr, char *buf,
   return len;
 }
 
-int rshim_log_show(rshim_backend_t *bd, char *buf, int size)
+/*
+ * Inner ring drain: acquire semaphore, read messages, write back ctl,
+ * release.  Emits only " LEVEL[MOD]: msg\n" body lines (no banner) into
+ * @buf.  When @force_clear is true the final ctl write is always 0 --
+ * used by the shadow-ring drainer, which is the sole consumer of the hw
+ * ring once the shadow is active.  When false the legacy behaviour
+ * applies: ctl is reset to 0 if clear_on_read is set, otherwise restored
+ * to the original idx.
+ *
+ * Must be called with bd->mutex held (read_rshim / write_rshim
+ * convention).
+ */
+static int rshim_log_drain_to_buf(rshim_backend_t *bd, char *buf, int size,
+                                  bool force_clear)
 {
   uint64_t data, idx, hdr;
   time_t t0, t1;
   int i, n, rc, type, len;
   char *p = buf;
-
-  n = snprintf(p, size, "---------------------------------------\n");
-  p += n;
-  size -= n;
-  n = snprintf(p, size, "             Log Messages\n");
-  p += n;
-  size -= n;
-  n = snprintf(p, size, "---------------------------------------\n");
-  p += n;
-  size -= n;
 
   /* Take the semaphore. */
   time(&t0);
@@ -339,7 +342,8 @@ int rshim_log_show(rshim_backend_t *bd, char *buf, int size)
   if (idx <= 1)
     goto done;
 
-  /* Reset the index to 0. */
+  /* Reset the index to 0 so subsequent scratch_buf_dat reads start
+   * from word 0 of the live ring. */
   rc = bd->write_rshim(bd, RSHIM_CHANNEL, bd->regs->scratch_buf_ctl, 0,
                        RSHIM_REG_SIZE_8B);
   if (rc) {
@@ -386,9 +390,10 @@ int rshim_log_show(rshim_backend_t *bd, char *buf, int size)
     }
   }
 
-  /* Clear or Restore the idx value. */
+  /* Clear or restore the idx value. */
   bd->write_rshim(bd, RSHIM_CHANNEL, bd->regs->scratch_buf_ctl,
-                  bd->clear_on_read ? 0 : idx, RSHIM_REG_SIZE_8B);
+                  (force_clear || bd->clear_on_read) ? 0 : idx,
+                  RSHIM_REG_SIZE_8B);
 
 done:
   /* Release the semaphore. */
@@ -396,4 +401,454 @@ done:
                   RSHIM_REG_SIZE_8B);
 
   return p - buf;
+}
+
+int rshim_log_show(rshim_backend_t *bd, char *buf, int size)
+{
+  char *p = buf;
+  int n;
+
+  n = snprintf(p, size, "---------------------------------------\n");
+  p += n;
+  size -= n;
+  n = snprintf(p, size, "             Log Messages\n");
+  p += n;
+  size -= n;
+  n = snprintf(p, size, "---------------------------------------\n");
+  p += n;
+  size -= n;
+
+  /* Drain into the caller's buffer with the legacy clear-or-restore
+   * policy (honours bd->clear_on_read).  Used by rshim_fuse_misc_read()
+   * at DISPLAY_LEVEL 2 when the shadow ring is disabled. */
+  n = rshim_log_drain_to_buf(bd, p, size, false);
+  p += n;
+
+  return p - buf;
+}
+
+int rshim_log_drain(rshim_backend_t *bd)
+{
+  uint64_t data;
+  time_t t0, t1;
+  int rc;
+
+  /*
+   * Acquire semaphore0.  This is the same coordination protocol used by
+   * rshim_log_show(): poll the hw semaphore until we read 0 (free), at
+   * which point the read implicitly takes it.  Bail out after 3 seconds
+   * so a wedged DPU doesn't block the misc read indefinitely.
+   */
+  time(&t0);
+  while (true) {
+    data = 0x1;
+    rc = bd->read_rshim(bd, RSHIM_CHANNEL, bd->regs->semaphore0, &data,
+                        RSHIM_REG_SIZE_8B);
+    if (rc || RSHIM_BAD_CTRL_REG(data)) {
+      RSHIM_ERR("rshim%d failed to read RSH_SEMAPHORE0(%d)\n", bd->index, rc);
+      return -EIO;
+    }
+    if (!data)
+      break;
+
+    time(&t1);
+    if (difftime(t1, t0) > 3)
+      return -EBUSY;
+  }
+
+  /*
+   * Reset the write index.  We deliberately do not honour clear_on_read
+   * here -- this function exists precisely to discard the ring contents.
+   * Any data the DPU has written is dropped on the floor.
+   */
+  bd->write_rshim(bd, RSHIM_CHANNEL, bd->regs->scratch_buf_ctl, 0,
+                  RSHIM_REG_SIZE_8B);
+
+  /* Release the semaphore. */
+  bd->write_rshim(bd, RSHIM_CHANNEL, bd->regs->semaphore0, 0,
+                  RSHIM_REG_SIZE_8B);
+
+  return 0;
+}
+
+int rshim_log_write(rshim_backend_t *bd, int module, int level,
+                    const char *msg)
+{
+  const int mod_count = (int)(sizeof(rshim_log_mod) / sizeof(rshim_log_mod[0]));
+  const int lvl_count =
+      (int)(sizeof(rshim_log_levels) / sizeof(rshim_log_levels[0]));
+  const int word_sz = (int)sizeof(uint64_t);
+  uint64_t data, idx, hdr;
+  time_t t0, t1;
+  int rc, len, num, i;
+
+  if (!bd || !msg || !*msg)
+    return -EINVAL;
+  if (module < 0 || module >= mod_count)
+    module = 0;
+  if (level < 0 || level >= lvl_count)
+    level = 0;
+
+  len = (int)strlen(msg);
+  num = (len + word_sz - 1) / word_sz;
+
+  /*
+   * Acquire semaphore0 using the same poll-and-timeout protocol as
+   * rshim_log_show() / rshim_log_drain().  Reading 0 from semaphore0
+   * implicitly takes ownership; we bail after 3 seconds to keep a
+   * wedged DPU from blocking the caller.
+   */
+  time(&t0);
+  while (true) {
+    data = 0x1;
+    rc = bd->read_rshim(bd, RSHIM_CHANNEL, bd->regs->semaphore0, &data,
+                        RSHIM_REG_SIZE_8B);
+    if (rc || RSHIM_BAD_CTRL_REG(data)) {
+      RSHIM_ERR("rshim%d failed to read RSH_SEMAPHORE0(%d)\n", bd->index, rc);
+      return -EIO;
+    }
+    if (!data)
+      break;
+
+    time(&t1);
+    if (difftime(t1, t0) > 3)
+      return -EBUSY;
+  }
+
+  /* Read the current write index. */
+  rc = bd->read_rshim(bd, RSHIM_CHANNEL, bd->regs->scratch_buf_ctl, &idx,
+                      RSHIM_REG_SIZE_8B);
+  if (rc) {
+    RSHIM_ERR("rshim%d failed to read RSH_SCRATCH_BUF_CTL(%d)\n",
+              bd->index, rc);
+    rc = -EIO;
+    goto done;
+  }
+  idx = (idx >> RSH_SCRATCH_BUF_CTL__IDX_SHIFT) & RSH_SCRATCH_BUF_CTL__IDX_MASK;
+
+  /*
+   * Truncate the payload if the ring can't hold header + num words.
+   * The IDX field is 7 bits (RSH_SCRATCH_BUF_CTL__IDX_MASK = 0x7f), so
+   * the absolute maximum is 128 words shared between header and body.
+   * Match the legacy mlx-bootctl behaviour: keep the framing intact and
+   * write a shorter message rather than refusing.
+   */
+  if ((int)idx + num + 1 > (int)RSH_SCRATCH_BUF_CTL__IDX_MASK)
+    num = (int)RSH_SCRATCH_BUF_CTL__IDX_MASK - (int)idx - 1;
+  if (num <= 0) {
+    rc = -ENOSPC;
+    goto done;
+  }
+
+  /*
+   * Header layout (matches what rshim_log_show_msg() decodes):
+   *   [63:60] module   [59:56] type   [55:48] len (8-byte words)
+   *   [47:16] arg      [15:8]  has_arg [7:0]  level
+   * Wire format is little-endian (reader does le64toh()).
+   */
+  hdr = ((uint64_t)(module & BF_RSH_LOG_MOD_MASK)  << BF_RSH_LOG_MOD_SHIFT)   |
+        ((uint64_t)BF_RSH_LOG_TYPE_MSG             << BF_RSH_LOG_TYPE_SHIFT)  |
+        (((uint64_t)num & BF_RSH_LOG_LEN_MASK)     << BF_RSH_LOG_LEN_SHIFT)   |
+        ((uint64_t)(level & BF_RSH_LOG_LEVEL_MASK) << BF_RSH_LOG_LEVEL_SHIFT);
+  hdr = htole64(hdr);
+  rc = bd->write_rshim(bd, RSHIM_CHANNEL, bd->regs->scratch_buf_dat, hdr,
+                       RSHIM_REG_SIZE_8B);
+  if (rc) {
+    RSHIM_ERR("rshim%d failed to write log header(%d)\n", bd->index, rc);
+    rc = -EIO;
+    goto done;
+  }
+
+  /*
+   * Pack the message body 8 bytes at a time, NUL-padding the tail of
+   * the last word.  The reader (rshim_log_show_msg) allocates
+   * num*8 + 1 bytes and memcpys these words straight in, then NUL
+   * terminates -- so any trailing zeros here become string terminator.
+   */
+  for (i = 0; i < num; i++) {
+    data = 0;
+    if (len <= word_sz) {
+      memcpy(&data, msg, len);
+      len = 0;
+    } else {
+      memcpy(&data, msg, word_sz);
+      msg += word_sz;
+      len -= word_sz;
+    }
+    rc = bd->write_rshim(bd, RSHIM_CHANNEL, bd->regs->scratch_buf_dat, data,
+                         RSHIM_REG_SIZE_8B);
+    if (rc) {
+      RSHIM_ERR("rshim%d failed to write log payload(%d)\n", bd->index, rc);
+      rc = -EIO;
+      goto done;
+    }
+  }
+
+  rc = 0;
+
+done:
+  /* Release the semaphore. */
+  bd->write_rshim(bd, RSHIM_CHANNEL, bd->regs->semaphore0, 0,
+                  RSHIM_REG_SIZE_8B);
+  return rc;
+}
+
+/* --------------------------------------------------------------------------
+ * DPU log shadow ring -- background drainer + cumulative reader view.
+ *
+ * The hw scratch ring's IDX field is 7 bits wide, so the live ring tops
+ * out at 128 8-byte words (1 KiB).  Once it saturates the DPU silently
+ * drops further entries (the "Updating DPU Gol" cliff).  CLEAR_ON_READ=1
+ * keeps it drained but is destructive: every reader competes with every
+ * other for the same bytes, which breaks bfb-install's exit-pattern
+ * polling whenever the user is also tailing the misc node.
+ *
+ * The shadow ring decouples those two roles:
+ *
+ *   producer  : rshim_log_shadow_tick(), invoked from the worker every
+ *               RSHIM_LOG_SHADOW_DRAIN_MS ms.  Pulls everything from the
+ *               hw ring into the shadow with force_clear=true.
+ *   consumer  : rshim_log_shadow_render(), called from
+ *               rshim_fuse_misc_read() at DISPLAY_LEVEL 2.  Non-
+ *               destructive by default; honours CLEAR_ON_READ when set.
+ *
+ * Both run under bd->mutex.  No additional locking required.
+ * -------------------------------------------------------------------------- */
+
+/* Polling cadence for the shadow drainer.  500 ms is well under the DPU's
+ * 128-word saturation interval at typical install burst rates (~6 msgs/s
+ * peak ≈ 36 words/s) while costing one register read + one semaphore
+ * round-trip per tick. */
+#define RSHIM_LOG_SHADOW_DRAIN_MS 500
+
+/* Round @v up to the next power of two.  Returns 0 if v == 0. */
+static size_t rshim_log_shadow_round_pow2(size_t v)
+{
+  size_t r = 1;
+
+  if (!v)
+    return 0;
+  while (r < v)
+    r <<= 1;
+  return r;
+}
+
+int rshim_log_shadow_init(rshim_backend_t *bd, size_t cap)
+{
+  struct rshim_log_shadow *s;
+
+  if (!bd || bd->log_shadow)
+    return -EINVAL;
+  if (!cap)
+    return 0;   /* explicit "disabled" -- caller checked rshim_log_shadow_size */
+
+  cap = rshim_log_shadow_round_pow2(cap);
+
+  s = calloc(1, sizeof(*s));
+  if (!s)
+    return -ENOMEM;
+
+  s->buf = calloc(1, cap);
+  if (!s->buf) {
+    free(s);
+    return -ENOMEM;
+  }
+  s->cap = cap;
+  s->head = 0;
+  s->tail = 0;
+  s->dropped_bytes = 0;
+  s->next_drain_tick = 0;  /* drain on the first tick we see */
+
+  bd->log_shadow = s;
+  return 0;
+}
+
+void rshim_log_shadow_free(rshim_backend_t *bd)
+{
+  if (!bd || !bd->log_shadow)
+    return;
+
+  free(bd->log_shadow->buf);
+  free(bd->log_shadow);
+  bd->log_shadow = NULL;
+}
+
+void rshim_log_shadow_reset(rshim_backend_t *bd)
+{
+  struct rshim_log_shadow *s;
+
+  if (!bd || !bd->log_shadow)
+    return;
+
+  s = bd->log_shadow;
+  s->head = 0;
+  s->tail = 0;
+  s->dropped_bytes = 0;
+  /* Leave next_drain_tick alone: cadence is a property of the drainer,
+   * not the buffer.  Zeroing it would force an extra drain on the next
+   * tick, which is harmless but unnecessary. */
+}
+
+/*
+ * Append @n bytes from @src into the shadow ring.  When the incoming
+ * data would overflow the ring we drop the *oldest* bytes (advance
+ * tail) so the most recent state-of-the-world is always retained --
+ * that's what an install monitor cares about.  We also track total
+ * dropped bytes for the misc summary.
+ */
+static void rshim_log_shadow_append(rshim_backend_t *bd,
+                                    const char *src, size_t n)
+{
+  struct rshim_log_shadow *s;
+  size_t used, drop, off, first;
+
+  if (!bd || !bd->log_shadow || !bd->log_shadow->buf || !n)
+    return;
+
+  s = bd->log_shadow;
+
+  /* If a single chunk is larger than the entire ring, retain only the
+   * trailing cap-1 bytes (leave one byte gap so head != tail meaning
+   * "full" is unambiguous). */
+  if (n >= s->cap) {
+    s->dropped_bytes += n - (s->cap - 1);
+    src += n - (s->cap - 1);
+    n = s->cap - 1;
+    s->head = s->tail = 0;
+  }
+
+  used = s->head - s->tail;
+  if (used + n > s->cap - 1) {
+    drop = used + n - (s->cap - 1);
+    s->tail += drop;
+    s->dropped_bytes += drop;
+  }
+
+  off = s->head & (s->cap - 1);
+  first = (off + n <= s->cap) ? n : s->cap - off;
+  memcpy(s->buf + off, src, first);
+  if (first < n)
+    memcpy(s->buf, src + first, n - first);
+  s->head += n;
+}
+
+int rshim_log_shadow_flush(rshim_backend_t *bd)
+{
+  char tmp[1280];   /* upper bound: 128-word ring fully populated with msg text */
+  int n;
+
+  if (!bd || !bd->log_shadow || !bd->log_shadow->buf || !bd->has_rshim ||
+      bd->drop_mode || bd->in_access_check ||
+      bd->is_boot_open || bd->is_booting)
+    return 0;
+
+  /* Always force-clear the hw ring so the DPU never sees a near-full
+   * scratch_buf_ctl IDX.  Any subsequent direct readers of the live
+   * ring (display_level != 2 paths with rshim_log_drain in misc_read)
+   * are independent of this drainer and don't care that we cleared. */
+  n = rshim_log_drain_to_buf(bd, tmp, sizeof(tmp), true);
+  if (n > 0)
+    rshim_log_shadow_append(bd, tmp, (size_t)n);
+
+  return n > 0 ? n : 0;
+}
+
+int rshim_log_shadow_msg(rshim_backend_t *bd, int module, int level,
+                         const char *msg)
+{
+  const int mod_count = (int)(sizeof(rshim_log_mod) / sizeof(rshim_log_mod[0]));
+  const int lvl_count =
+      (int)(sizeof(rshim_log_levels) / sizeof(rshim_log_levels[0]));
+  char line[1024];
+  int n;
+
+  if (!bd || !bd->log_shadow || !bd->log_shadow->buf || !msg || !*msg)
+    return -EINVAL;
+  if (module < 0 || module >= mod_count)
+    module = 0;
+  if (level < 0 || level >= lvl_count)
+    level = 0;
+
+  /* Match the wire format produced by rshim_log_show_msg() so a misc
+   * read can't tell host-injected entries from DPU-emitted ones.  The
+   * 1024 KiB scratch is more than enough; LOG_MSG line lengths in
+   * practice are well under 200 bytes. */
+  n = snprintf(line, sizeof(line), " %s[%s]: %s\n",
+               rshim_log_levels[level], rshim_log_mod[module], msg);
+  if (n <= 0)
+    return -EINVAL;
+  if (n >= (int)sizeof(line))
+    n = (int)sizeof(line) - 1;   /* truncate, keep newline implicit */
+
+  rshim_log_shadow_append(bd, line, (size_t)n);
+  return 0;
+}
+
+void rshim_log_shadow_tick(rshim_backend_t *bd, int now_ticks)
+{
+  if (!bd || !bd->log_shadow)
+    return;
+
+  /* Rate-limit polling.  Tick counter is in milliseconds; signed
+   * subtraction handles wrap-around. */
+  if ((bd->log_shadow->next_drain_tick - now_ticks) > 0)
+    return;
+  bd->log_shadow->next_drain_tick = now_ticks + RSHIM_LOG_SHADOW_DRAIN_MS;
+
+  (void)rshim_log_shadow_flush(bd);
+}
+
+int rshim_log_shadow_render(rshim_backend_t *bd, char *out, int max)
+{
+  struct rshim_log_shadow *s;
+  char *p = out;
+  size_t used, off, first;
+  int n, room;
+
+  if (!bd || !bd->log_shadow || !bd->log_shadow->buf || !out || max <= 0)
+    return 0;
+
+  s = bd->log_shadow;
+  room = max;
+
+  /* Banner -- identical to rshim_log_show() so misc output format is
+   * unchanged.  Bounds-check each snprintf so a tight caller buffer
+   * can't push the cursor past the end. */
+  n = snprintf(p, room, "---------------------------------------\n");
+  if (n < 0 || n >= room)
+    return p - out;
+  p += n;
+  room -= n;
+
+  n = snprintf(p, room, "             Log Messages\n");
+  if (n < 0 || n >= room)
+    return p - out;
+  p += n;
+  room -= n;
+
+  n = snprintf(p, room, "---------------------------------------\n");
+  if (n < 0 || n >= room)
+    return p - out;
+  p += n;
+  room -= n;
+
+  used = s->head - s->tail;
+  if (used > (size_t)room)
+    used = (size_t)room;   /* truncate to fit caller's buffer */
+
+  if (used) {
+    off = s->tail & (s->cap - 1);
+    first = (off + used <= s->cap) ? used : s->cap - off;
+    memcpy(p, s->buf + off, first);
+    if (first < used)
+      memcpy(p + first, s->buf, used - first);
+    p += used;
+  }
+
+  /* Destructive read when clear_on_read=1: consume what we just
+   * rendered.  Other readers will see only newer content from here on. */
+  if (bd->clear_on_read)
+    s->tail += used;
+
+  return p - out;
 }


### PR DESCRIPTION
rshim: software shadow ring for the DPU log scratch buffe

#4980265

- Add a per-backend software shadow ring that mirrors the DPU's 1 KiB / 7-bit hardware log scratch buffer, fixing the install-time `Updating DPU Gol?` truncation that operators hit once the live ring saturates (~25 log lines).
- Reset the shadow on `boot-open` so each new bfb push starts with a clean log instead of inheriting the pre-install boot session's BL1/BL2 prologue.
- Add a `LOG_MSG` misc write command so host-side scripts can inject log lines without being rate-limited by the 7-bit HW ring (200-message bursts now land all 200; previously capped at ~21).
- LOG_SHADOW_SIZE  default 64 KiB.

A circular buffer in struct rshim_backend decouples producers from consumers. All shadow operations are serialized by the existing bd->mutex; no new locks introduced.

Role	  Function	            Notes
Drainer   rshim_log_shadow_tick()   Worker hook, 500 ms cadence.
                                    Pulls HW ring with force_clear=true.
                                    Gated off via is_boot_open || is_booting
                                    so it never contends with the boot push.

Host      rshim_log_shadow_msg()    Used by the new LOG_MSG command. Writes
injection                           straight to the shadow, bypasses the
                                    7-bit HW ring entirely.

Reader    rshim_log_shadow_render() Called from rshim_fuse_misc_read() at
                                    DISPLAY_LEVEL 2. Non-destructive by default;
                                    honors CLEAR_ON_READ=1 by advancing tail
                                    post-render.

Reset     rshim_log_shadow_reset()  Called from rshim_boot_open() right after
                                    is_boot_open = 1 so a fresh bfb push starts
                                    with a clean log.
Using LOG_MSG

 echo "LOG_MSG [LEVEL] <text>" > /dev/rshim<N>/misc

 - LEVEL (optional, case-sensitive): INFO | WARN | ERR | ASSERT. Defaults to INFO.

 - Module is hard-coded to MISC (host-originated); entries render as LEVEL[MISC]: <text>.

 - Free-form text up to ~1 KiB. No quoting required beyond shell rules.

Backward compatibility

 - log_shadow pointer appended at the end of rshim_backend_t. Offsets of all preceding fields (notably read_rshim / write_rshim function pointers) are unchanged - partial rebuilds against the new header don't corrupt anything.

 - LOG_SHADOW_SIZE 0 -> bd->log_shadow == NULL and every shadow function early-returns. Misc read falls back to the original rshim_log_show() with its clear-or-restore-IDX semantics. Identical behavior to the previous release.

 - CLEAR_ON_READ still controls whether the misc read is destructive; only the substrate it acts on (HW ring vs shadow) changes.

Test plan/execution results

 - Truncation fix verified on BlueField-3 / USB rshim: full bf-bundle install transcript captured from PSC BL1 START through "Installation finished / Rebooting..." , no "Updating DPU Gol" cliff.

 - Boot-open reset verified: after scp bf-bundle ... /dev/rshim0/boot, misc log starts at boot mode (rshim); pre-install boot mode (emmc) block is gone.

 - LOG_MSG 200-message burst: shadow occupancy ~10 KiB / 65536, LOG_DROPPED 0. Legacy HW-only path saturates at 21 messages.

 - Concurrent readers: bfb-install exit-pattern poller + "watch -n 5 cat /dev/rshim0/misc" both observe consistent, non-racing content.

 - LOG_SHADOW_SIZE 0: behavior, semaphore protocol, and CLEAR_ON_READ semantics identical to pre-patch baseline.

 - No scp throughput regression: side-by-side measured at ~4.6 MB/s on both pre-patch and post-patch binaries.