### PR TITLE
fix mft not working in chroot env

### DIFF
--- a/scripts/bfb-tool
+++ b/scripts/bfb-tool
@@ -807,7 +807,7 @@ handle_opn()
 
 	# Create mlxfwmanager with single FW binary
 	cp $NIC_FW ${INITRAMFS_REPKG_DIR}/opt/mellanox/mlnx-fw-updater/firmware/
-	chroot ${INITRAMFS_REPKG_DIR} /usr/bin/mlx_fwsfx_gen --source-dir /opt/mellanox/mlnx-fw-updater/firmware/ --out-dir /opt/mellanox/mlnx-fw-updater/firmware/ --sfx-name ${mlxfwmanager##*/} > /dev/null 2>&1
+	chroot ${INITRAMFS_REPKG_DIR} env LD_LIBRARY_PATH=/usr/lib64/mft /usr/bin/mlx_fwsfx_gen --source-dir /opt/mellanox/mlnx-fw-updater/firmware/ --out-dir /opt/mellanox/mlnx-fw-updater/firmware/ --sfx-name ${mlxfwmanager##*/} > /dev/null 2>&1
 	if [ $? -ne 0 ]; then
 		echo "ERROR: Failed to build mlxfwmanager for ${BOARD_ID}"
 		exit 1


### PR DESCRIPTION
Manual backport of 307c7956ea34d7bfd9b7b46f2569b86c88bed218. The mlx_fwsfx_gen line is identical to master; only surrounding context differs on this branch, so cherry-pick was applied as a one-line change.