### PR TITLE
Bug fix: Allow ownership transfer request from rshim_pcie_lf DROP_MODE

### DIFF
--- a/src/rshim_pcie_lf.c
+++ b/src/rshim_pcie_lf.c
@@ -693,7 +693,7 @@ rshim_pcie_read(struct rshim_backend *bd, uint32_t chan, uint32_t addr,
   if (size != 4 && size != 8)
     return -EINVAL;
 
-  if (bd->drop_mode) {
+  if (bd->drop_mode && !bd->requesting_rshim) {
     *result = 0;
     return 0;
   }
@@ -726,7 +726,7 @@ rshim_pcie_write(struct rshim_backend *bd, uint32_t chan, uint32_t addr,
   if (size != 4 && size != 8)
     return -EINVAL;
 
-  if (bd->drop_mode)
+  if (bd->drop_mode && !bd->requesting_rshim)
     return 0;
 
   if (pci_dev->device_id == BLUEFIELD3_DEVICE_ID) {


### PR DESCRIPTION
Since rshim_pcie_lf backend alone starts in DROP_MODE by default, the ownership transfer request is never sent out even if "--force" is specified. So ownership can never be retrieved by the pcie_lf host, only the other way round would work. Fix this by allowing the ownership transfer request to go through even in DROP_MODE.

RM #4564194