### PR TITLE
rshim: retry stalled boot writes

### DIFF
--- a/src/rshim.c
+++ b/src/rshim.c
@@ -856,7 +856,8 @@ boot_open_done:
 }
 
 int rshim_boot_write(rshim_backend_t *bd, const char *user_buffer, size_t count,
-                     int (*copy_in)(void *dest, const void *src, int count))
+                     int (*copy_in)(void *dest, const void *src, int count),
+                     int (*interrupted)(void *arg), void *interrupted_arg)
 {
   int rc = 0, whichbuf = 0, len;
   time_t tm;
@@ -887,6 +888,11 @@ int rshim_boot_write(rshim_backend_t *bd, const char *user_buffer, size_t count,
                            (count + bd->boot_rem_cnt) & (-((size_t)8)));
     char *buf = bd->boot_buf[whichbuf];
 
+    if (interrupted && interrupted(interrupted_arg)) {
+      rc = -EINTR;
+      break;
+    }
+
     whichbuf ^= 1;
 
     /* Copy the previous remaining data first. */
@@ -911,7 +917,19 @@ int rshim_boot_write(rshim_backend_t *bd, const char *user_buffer, size_t count,
         rc = -ETIMEDOUT;
         RSHIM_INFO("rshim%d boot timeout\n", bd->index);
       } else {
-        rc = -EINTR;
+        /*
+         * No boot FIFO space is available yet. Keep the write pending until
+         * the peer drains space or the boot timeout expires, but don't block
+         * console/network/misc handling while waiting to retry.
+         */
+        pthread_mutex_unlock(&bd->mutex);
+        usleep(1000);
+        pthread_mutex_lock(&bd->mutex);
+        if (interrupted && interrupted(interrupted_arg)) {
+          rc = -EINTR;
+          break;
+        }
+        continue;
       }
       break;
     }

--- a/src/rshim.h
+++ b/src/rshim.h
@@ -607,7 +607,8 @@ void rshim_ref(rshim_backend_t *bd);
 void rshim_deref(rshim_backend_t *bd);
 int rshim_boot_open(rshim_backend_t *bd);
 int rshim_boot_write(rshim_backend_t *bd, const char *user_buffer, size_t count,
-                     int (*copy_in)(void *dest, const void *src, int count));
+                     int (*copy_in)(void *dest, const void *src, int count),
+                     int (*interrupted)(void *arg), void *interrupted_arg);
 void rshim_boot_release(rshim_backend_t *bd);
 int rshim_console_open(rshim_backend_t *bd);
 int rshim_console_release(rshim_backend_t *bd,

--- a/src/rshim_fuse.c
+++ b/src/rshim_fuse.c
@@ -111,6 +111,11 @@ static int rshim_fuse_copy_in(void *dest, const void *src, int count)
   return 0;
 }
 
+static int rshim_fuse_boot_write_interrupted(void *arg)
+{
+  return fuse_req_interrupted((fuse_req_t)arg);
+}
+
 static void rshim_fuse_boot_write(fuse_req_t req, const char *user_buffer,
                                   size_t count, off_t off,
                                   struct fuse_file_info *fi)
@@ -119,7 +124,8 @@ static void rshim_fuse_boot_write(fuse_req_t req, const char *user_buffer,
   int rc = -ENODEV;
 
   if (bd)
-    rc = rshim_boot_write(bd, user_buffer, count, rshim_fuse_copy_in);
+    rc = rshim_boot_write(bd, user_buffer, count, rshim_fuse_copy_in,
+                          rshim_fuse_boot_write_interrupted, req);
 
   if (rc >= 0)
     fuse_reply_write(req, rc);
@@ -138,7 +144,8 @@ static int rshim_fuse_boot_write(struct cuse_dev *cdev, int fflags,
   rshim_backend_t *bd = cuse_dev_get_priv0(cdev);
   int rc;
 
-  rc = rshim_boot_write(bd, user_buffer, count, rshim_fuse_copy_in);
+  rc = rshim_boot_write(bd, user_buffer, count, rshim_fuse_copy_in,
+                        NULL, NULL);
 
   switch (rc) {
   case 0:
@@ -1333,14 +1340,37 @@ static const struct cuse_methods rshim_rshim_fops = {
 };
 #endif
 
+#ifdef __linux__
+struct cuse_worker_arg {
+  struct fuse_session *se;
+  int multithreaded;
+};
+#endif
+
 static void *cuse_worker(void *arg)
 {
 #ifdef __linux__
-  struct fuse_session *se = arg;
+  struct cuse_worker_arg *warg = arg;
+  struct fuse_session *se = warg->se;
   int rc;
 
-  rc = fuse_session_loop(se);
+  /*
+   * The boot session runs a multithreaded loop so an idle worker thread can
+   * receive and process a FUSE interrupt (e.g. Ctrl-C on the writer) while a
+   * boot write is stalled waiting for the peer to drain the boot FIFO. Other
+   * sessions keep the single-threaded loop.
+   */
+  if (warg->multithreaded) {
+#if FUSE_USE_VERSION >= 30
+    rc = fuse_session_loop_mt(se, 0);
+#else
+    rc = fuse_session_loop_mt(se);
+#endif
+  } else {
+    rc = fuse_session_loop(se);
+  }
   fuse_session_destroy(se);
+  free(warg);
 
   return (void *)(unsigned long)rc;
 #elif defined(__FreeBSD__)
@@ -1409,10 +1439,17 @@ int rshim_fuse_init(rshim_backend_t *bd)
       return -1;
     }
     fuse_remove_signal_handlers(bd->fuse_session[i]);
-    rc = pthread_create(&bd->fuse_thread[i], NULL, cuse_worker,
-                        bd->fuse_session[i]);
+    struct cuse_worker_arg *warg = calloc(1, sizeof(*warg));
+    if (!warg) {
+      RSHIM_ERR("rshim%d failed to alloc cuse worker arg\n", bd->index);
+      return -1;
+    }
+    warg->se = bd->fuse_session[i];
+    warg->multithreaded = (i == RSH_DEV_TYPE_BOOT);
+    rc = pthread_create(&bd->fuse_thread[i], NULL, cuse_worker, warg);
     if (rc) {
       RSHIM_ERR("rshim%d failed to create cuse thread\n", bd->index);
+      free(warg);
       return rc;
     }
 #elif defined(__FreeBSD__)


### PR DESCRIPTION
A boot write can temporarily make no progress when the BlueField boot FIFO has no space. The current path treats that zero-progress case as -EINTR, so writing a BFB to /dev/rshim<N>/boot can fail even though the caller was not interrupted.

Retry zero-progress writes until the FIFO drains or the existing boot timeout expires. Keep the wait interruptible so Ctrl-C can abort a stalled transfer, and keep releasing the backend mutex during the retry delay so other rshim operations can continue.

Cherry-picked from master branch.
Orig RM #5110797

RM #5124285