### PR TITLE
bfb-tool: bind-mount host device nodes into chroots

### DIFF
--- a/scripts/bfb-tool
+++ b/scripts/bfb-tool
@@ -72,7 +72,44 @@ EOF
 }
 
 finish() {
+	unbind_mount_chroot_devices
 	[ -n "$WDIR" ] && rm -rf "$WDIR"
+}
+
+# Bind-mount real device nodes from the host into a chroot before running
+# scripts inside it. A chroot's working directory can end up on a 'nodev'
+# filesystem: cpio still creates the device-node inodes, but opening them
+# for I/O then fails with "Permission denied", breaking feature checks such
+# as `which python3 >/dev/null 2>&1` used by some vendored tools. A bind
+# mount takes the *source* mount's permissions, so it works regardless of
+# how the chroot directory itself is mounted.
+CHROOT_DEV_NODES="null zero full random urandom tty"
+CHROOT_BIND_MOUNTS=()
+
+bind_mount_chroot_devices() {
+	local chroot_dir=$1
+	local dev target
+
+	for dev in $CHROOT_DEV_NODES; do
+		target="${chroot_dir}/dev/${dev}"
+		# Only bind real char devices where the chroot already has a node to shadow.
+		[ -c "/dev/${dev}" ] || continue
+		[ -e "$target" ] || continue
+		if mount --bind "/dev/${dev}" "$target" 2> /dev/null; then
+			CHROOT_BIND_MOUNTS+=("$target")
+		elif [ $verbose -eq 1 ]; then
+			warn "Failed to bind-mount /dev/${dev} into ${chroot_dir}/dev"
+		fi
+	done
+}
+
+unbind_mount_chroot_devices() {
+	local target
+
+	for target in "${CHROOT_BIND_MOUNTS[@]}"; do
+		umount "$target" 2> /dev/null
+	done
+	CHROOT_BIND_MOUNTS=()
 }
 
 extract_bf_cfg_from_config_image() {
@@ -528,6 +565,8 @@ cd $INITRAMFS_WDIR
 info "Extracting BFB's initramfs"
 gzip -d < ../dump-initramfs-v0 | cpio -id
 
+bind_mount_chroot_devices "$INITRAMFS_WDIR"
+
 if ! (/bin/ls */install.env/common > /dev/null 2>&1); then
     error "This BFB does not support BMC components update"
     exit 1
@@ -605,6 +644,8 @@ if [ $REPACK -eq 1 ]; then
 	mkdir -p $INITRAMFS_REPKG_DIR
 	cd $INITRAMFS_REPKG_DIR
 	gzip -d < ../dump-initramfs-v0 | cpio -id
+
+	bind_mount_chroot_devices "$INITRAMFS_REPKG_DIR"
 
 	if [ ! -d ./opt/mellanox/mlnx-fw-updater  ]; then
 	    info "Extracting mlnx-fw-updater"


### PR DESCRIPTION
Cherry-pick of #412 (d4158f5) to 2.8.x.

Chroot working directories can end up on a filesystem mounted with
'nodev' (e.g. hardened tmpfs /tmp). cpio still creates the device-node
inodes during extraction, but opening them for I/O then fails with
"Permission denied", regardless of the node's permission bits. This
silently breaks '>/dev/null' feature-detection idioms used by some
vendored tools running inside the chroot (e.g. `which python3
>/dev/null 2>&1`), which can then fall back to code paths that may not
exist in newer tool versions.

Bind-mount /dev/null and a few other common device nodes from the
host into the chroot before running anything inside it. A bind mount
takes on the source mount's permissions rather than the destination's,
so this works regardless of how the chroot directory itself is
mounted.

RM# 5165807