### PR TITLE
bfb-install: print BFB-Install deprecation notice to stdout on every run

### DIFF
--- a/scripts/bfb-install
+++ b/scripts/bfb-install
@@ -81,7 +81,7 @@ echo_dbg() {
 # BFB-Install deprecation notice. Printed as a header (at startup) and as a
 # footer (on exit) so it is shown for every bfb-install invocation.
 print_deprecation_note() {
-  cat >&2 <<'EOF'
+  cat <<'EOF'
 
 ***Note: DOCA 3.5 (July 2026 release) will be the last DOCA version to support BFB-Install. In the following DOCA release (Oct 2026) DOCA-Installer will replace the full functionality provided by BFB-Install, and BFB-Install will no longer be included in future DOCA packages. ***
 


### PR DESCRIPTION
Updated deprecation notice for BFB-Install to reflect changes in DOCA support - message needs to be printed to stdout